### PR TITLE
메이븐 의존성정보 오타 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ dependencies {
 </repositories>
 
 <dependency>
-	<groupId>org.springframework.boot</groupId>
-	<artifactId>com.navercorp.spring:spring-boot-starter-data-jdbc-plus-sql</artifactId>
+	<groupId>com.navercorp.spring</groupId>
+	<artifactId>spring-boot-starter-data-jdbc-plus-sql</artifactId>
 	<version>2.0.0.RC2</version>
 </dependency>
 <dependency>


### PR DESCRIPTION
README 의 정보를 수정합니다.


---

https://github.com/naver/spring-jdbc-plus/wiki/User-Guide#1-spring-boot-starter-data-jdbc-plus-sql

> 위키 페이지에도 동일한 오타가 있는데요, 수정가능한 권한이 없어서 언급만 드려요.
( 메이븐 의존성관련내용 2군데 )