### PR TITLE
Upgrade Spring Boot base version to 2.3.0.RELEASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.2.7.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.3.0.RELEASE")
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.2.7.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.3.0.RELEASE")
     }
 }
 

--- a/spring-boot-autoconfigure-data-jdbc-plus/src/main/java/org/springframework/data/jdbc/repository/config/JdbcConfiguration.java
+++ b/spring-boot-autoconfigure-data-jdbc-plus/src/main/java/org/springframework/data/jdbc/repository/config/JdbcConfiguration.java
@@ -1,6 +1,0 @@
-package org.springframework.data.jdbc.repository.config;
-
-// to support import removed files
-@Deprecated
-public class JdbcConfiguration {
-}


### PR DESCRIPTION
Spring Boot base 버전을 2.3.0.RELEASE 로  변경합니다.

불필요한 `JdbcConfiguration` 도 제거합니다.