### PR TITLE
Add ConditionalConverter and ConditionalUnwrapper to enable custom matching

### DIFF
--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/ConditionalConverter.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/ConditionalConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.jdbc.plus.support.parametersource.converter;
+
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * The interface ConditionalConverter.
+ * provides {@link Converter} functionality with custom type matching condition.
+ *
+ * @author JunHo Yoon
+ *
+ * @param <S> the source type
+ * @param <T> the target type
+ */
+public interface ConditionalConverter<S, T> extends Converter<S, T>, ValueMatcher {
+}

--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/ConditionalUnwrapper.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/ConditionalUnwrapper.java
@@ -1,0 +1,30 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.jdbc.plus.support.parametersource.converter;
+
+/**
+ * The interface ConditionalUnwrapper.
+ * provides {@link Unwrapper} functionality with custom matching condition.
+ *
+ * @author JunHo Yoon
+ *
+ * @param <T> the type parameter
+ */
+public interface ConditionalUnwrapper<T> extends Unwrapper<T>, ValueMatcher {
+}

--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/ValueMatcher.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/ValueMatcher.java
@@ -1,0 +1,38 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-present NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.jdbc.plus.support.parametersource.converter;
+
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.lang.Nullable;
+
+/**
+ * The interface ConditionalMatcher.
+ * provide custom match functionality to make converters applied by custom matching logic.
+ *
+ * @author JunHo Yoon
+ */
+public interface ValueMatcher {
+	/**
+	 *
+	 * Evaluates if provided <var>value</var> is able to handled by this or not.
+	 * @param value the value which will be converted
+	 * @return true if matched, false otherwise
+	 */
+	boolean matches(Object value);
+}


### PR DESCRIPTION
현재 JdbcParameter를 SQL에 맵핑할때 현재값의 파라미터의 타입 기반으로 Converter 와 Unwrapper 를 찾습니다. (DefaultJdbcParameterSourceConverter)
대부분의 경우 문제 없으나 Jackson 등 내부에 다양한 상속 구조를 가진 경우,  
제공되는 모든 클래스에 대해 Conveter / Unwrapper 를 등록해야 JdbcParameter 로 사용가능합니다.

Converter / Unwrapper 구현을 간결화 하기 위해,  ValueMatcher 인터페이스를 구현한 ConditionalConverter 와 ConditionalUnwrapper 를 제공하고,  현재 Value에 따라 유연하게 Converter / Unwrapper를 선택할 수 있도록 합니다.

PR에 포함된 ValueMatcher 는 처음에는 TypeMatcher로 명명하고  match 메소드에 TypeDescriptor 파라미터를 받을까 했는데, TypeDescriptor 는 field / method type 등에서 사용되는 타입이라, 오히려 복잡함을 늘리는 느낌이었고, match 메소드에 Class 를 받자니, match 메소드 구현 난이도가 약간 올라갔습니다.

차라리 ValueMatcher 로 명명하고, match에 value를 받으니,  ```if ( value instanceof BlarBlar)``` 가 더 쉽게 matching 조건을 작성할 수 있어서, 이와 같이 구현했습니다.