### PR TITLE
Add @SqlTableAlias for generate columns table alias

### DIFF
--- a/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/annotation/SqlTableAlias.java
+++ b/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/annotation/SqlTableAlias.java
@@ -1,0 +1,35 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.sql.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The annotation Sql table alias
+ *
+ * @author Myeonghyeon Lee
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD})
+public @interface SqlTableAlias {
+	String value();
+}

--- a/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlGenerator.java
+++ b/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlGenerator.java
@@ -577,7 +577,7 @@ class SqlGenerator {
 				new PersistentPropertyPathExtension(mappingContext, path);
 			Column column = getColumn(extPath);
 			if (column != null) {
-				columnExpressions.add(column);
+				columnExpressions.add(getColumnExpression(extPath, column));
 			}
 		}
 
@@ -610,10 +610,10 @@ class SqlGenerator {
 			if (join != null) {
 				joinTables.add(join);
 			}
-
+			
 			Column column = getColumn(extPath);
 			if (column != null) {
-				columnExpressions.add(column);
+				columnExpressions.add(getColumnExpression(extPath, column));
 			}
 		}
 

--- a/spring-data-jdbc-plus-sql/src/test/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlProviderTest.java
+++ b/spring-data-jdbc-plus-sql/src/test/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlProviderTest.java
@@ -20,14 +20,19 @@ package com.navercorp.spring.data.jdbc.plus.sql.convert;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.jdbc.core.convert.BasicJdbcConverter;
+import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Embedded;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.relational.core.mapping.Table;
+
+import com.navercorp.spring.data.jdbc.plus.sql.annotation.SqlFunction;
+import com.navercorp.spring.data.jdbc.plus.sql.annotation.SqlTableAlias;
 
 /**
  * @author Myeonghyeon Lee
@@ -35,83 +40,180 @@ import org.springframework.data.relational.core.mapping.Table;
 class SqlProviderTest {
 	@Test
 	@DisplayName("테이블 기본 컬럼 생성 규칙")
-	@Disabled
 	void columns() {
 		// given
-		SqlProvider sut = null; //new SqlProvider(new RelationalMappingContext());
+		RelationalMappingContext context = new RelationalMappingContext();
+		JdbcConverter converter = new BasicJdbcConverter(context, (identifier, path) -> {
+			throw new UnsupportedOperationException();
+		});
+		SqlProvider sut = new SqlProvider(context, converter, NonQuotingDialect.INSTANCE);
 
 		// when
 		String columns = sut.columns(TestInnerEntity.class);
 
 		// then
-		assertThat(columns).isEqualTo(
-			"test_inner_entity.cty AS cty,\n"
-				+ "test_inner_entity.state AS state");
+		assertThat(columns).contains(
+			"test_inner_entity.cty AS cty, "
+			+ "test_inner_entity.state AS state"
+		);
 	}
 
 	@Test
-	@DisplayName("Embedded 된 column을 찾아가서 변환한다.")
-	@Disabled("SqlTableAlias 를 지원할 때까지 테스트를 Disabled 한다.")
-	void columnsWithEmbedded() {
+	@DisplayName("Embedded 와 Alias Table column 을 찾아가서 변환한다.")
+	void columnsWithEmbeddedAndAlias() {
 		// given
-		SqlProvider sut = null; // new SqlProvider(new RelationalMappingContext());
+		RelationalMappingContext context = new RelationalMappingContext();
+		JdbcConverter converter = new BasicJdbcConverter(context, (identifier, path) -> {
+			throw new UnsupportedOperationException();
+		});
+		SqlProvider sut = new SqlProvider(context, converter, NonQuotingDialect.INSTANCE);
 
 		// when
 		String columns = sut.columns(TestOuterEntity.class);
 
 		// then
-		assertThat(columns).isEqualTo(
-			"ts.tester_id AS tester_id,\n"
-				+ "ts.tester_nm AS tester_nm,\n"
-				+ "address.state AS adr_state,\n"
-				+ "address.cty AS adr_cty");
+		assertThat(columns).contains(
+			"ts.tester_id AS tester_id, "
+			+ "address.tester_outer_id AS testInner_tester_outer_id, "
+			+ "ts.tester_nm AS tester_nm, "
+			+ "address.cty AS testInner_cty, "
+			+ "address.state AS testInner_state, "
+			+ "ts.adr_cty AS adr_cty, "
+			+ "ts.adr_state AS adr_state"
+		);
 	}
 
 	@Test
-	@DisplayName("@SqlTemplate 은 Column 변환식을 사용한다")
-	@Disabled("SqlTableAlias 를 지원할 때까지 테스트를 Disabled 한다.")
+	@DisplayName("Root 에 @SqlTableAlias 이 없으면 Alias 가 없다.")
+	void columnsWithNoRootTableAlias() {
+		// given
+		RelationalMappingContext context = new RelationalMappingContext();
+		JdbcConverter converter = new BasicJdbcConverter(context, (identifier, path) -> {
+			throw new UnsupportedOperationException();
+		});
+		SqlProvider sut = new SqlProvider(context, converter, NonQuotingDialect.INSTANCE);
+
+		// when
+		String columns = sut.columns(TestEntityNoRootTableAlias.class);
+
+		// then
+		assertThat(columns).contains(
+			"test_entity_no_root_table_alias.root_id AS root_id, "
+				+ "test_entity_no_root_table_alias.root_name AS root_name, "
+				+ "tOuter.test_root_id AS testOuter_test_root_id, "
+				+ "tOuter.tester_id AS testOuter_tester_id, "
+				+ "tOuter_address.tester_outer_id AS testOuter_testInner_tester_outer_id, "
+				+ "tOuter.tester_nm AS testOuter_tester_nm, "
+				+ "test_entity_no_root_table_alias.outer_tester_id AS outer_tester_id, "
+				+ "outer_address.tester_outer_id AS outer_testInner_tester_outer_id, "
+				+ "test_entity_no_root_table_alias.outer_tester_nm AS outer_tester_nm, "
+				+ "tOuter_address.cty AS testOuter_testInner_cty, "
+				+ "tOuter_address.state AS testOuter_testInner_state, "
+				+ "tOuter.adr_cty AS testOuter_adr_cty, "
+				+ "tOuter.adr_state AS testOuter_adr_state, "
+				+ "outer_address.cty AS outer_testInner_cty, "
+				+ "outer_address.state AS outer_testInner_state, "
+				+ "test_entity_no_root_table_alias.outer_adr_cty AS outer_adr_cty, "
+				+ "test_entity_no_root_table_alias.outer_adr_state AS outer_adr_state"
+		);
+	}
+
+	@Test
+	@DisplayName("Nested 복합 클래스 컬럼 추출")
+	void columnsEmbeddedNestedTableAlias() {
+		// given
+		RelationalMappingContext context = new RelationalMappingContext();
+		JdbcConverter converter = new BasicJdbcConverter(context, (identifier, path) -> {
+			throw new UnsupportedOperationException();
+		});
+		SqlProvider sut = new SqlProvider(context, converter, NonQuotingDialect.INSTANCE);
+
+		// when
+		String columns = sut.columns(TestEmbeddedNested.class);
+
+		// then
+		assertThat(columns).contains(
+			"teie.root_id AS root_id, "
+				+ "teie.root_name AS root_name, "
+				+ "testOuter.test_root_id AS testOuter_test_root_id, "
+				+ "COALESCE(teie.age, 0) AS age, "
+				+ "teie.tester_id AS tester_id, "
+				+ "teie.tester_nm AS tester_nm, "
+				+ "testOuter.tester_id AS testOuter_tester_id, "
+				+ "testOuter_address.tester_outer_id AS testOuter_testInner_tester_outer_id, "
+				+ "testOuter.tester_nm AS testOuter_tester_nm, "
+				+ "teie.outer_tester_id AS outer_tester_id, "
+				+ "outer_address.tester_outer_id AS outer_testInner_tester_outer_id, "
+				+ "teie.outer_tester_nm AS outer_tester_nm, "
+				+ "testOuter_address.cty AS testOuter_testInner_cty, "
+				+ "testOuter_address.state AS testOuter_testInner_state, "
+				+ "testOuter.adr_cty AS testOuter_adr_cty, "
+				+ "testOuter.adr_state AS testOuter_adr_state, "
+				+ "outer_address.cty AS outer_testInner_cty, "
+				+ "outer_address.state AS outer_testInner_state, "
+				+ "teie.outer_adr_cty AS outer_adr_cty, "
+				+ "teie.outer_adr_state AS outer_adr_state"
+		);
+	}
+
+	@Test
+	@DisplayName("@SqlFunction 은 Column 변환식을 사용한다")
 	void columnsWithNonNullValue() {
 		// given
-		SqlProvider sut = null; // new SqlProvider(new RelationalMappingContext());
+		RelationalMappingContext context = new RelationalMappingContext();
+		JdbcConverter converter = new BasicJdbcConverter(context, (identifier, path) -> {
+			throw new UnsupportedOperationException();
+		});
+		SqlProvider sut = new SqlProvider(context, converter, NonQuotingDialect.INSTANCE);
 
 		// when
 		String columns = sut.columns(TestEntityWithNonNullValue.class);
 
 		// then
-		assertThat(columns).isEqualTo(
-			"ts.tester_id AS tester_id,\n"
-				+ "ts.tester_nm AS tester_nm,\n"
-				+ "COALESCE(ts.age, 0) as age");
+		assertThat(columns).contains(
+			"COALESCE(ts.age, 0) AS age, "
+				+ "ts.tester_id AS tester_id, "
+				+ "ts.tester_nm AS tester_nm"
+		);
 	}
 
 	@Test
 	@DisplayName("@Column 이 붙어있지 않으면, namingStrategy 를 따른다.")
-	@Disabled("SqlTableAlias 를 지원할 때까지 테스트를 Disabled 한다.")
 	void namingStrategyForNonColumnAnnotatedField() {
 		// given
-		SqlProvider sut = null; //new SqlProvider(new RelationalMappingContext(new PrefixingNamingStrategy()));
+		RelationalMappingContext context = new RelationalMappingContext(new PrefixingNamingStrategy());
+		JdbcConverter converter = new BasicJdbcConverter(context, (identifier, path) -> {
+			throw new UnsupportedOperationException();
+		});
+		SqlProvider sut = new SqlProvider(context, converter, NonQuotingDialect.INSTANCE);
 
 		// when
 		String columns = sut.columns(TestOuterEntity.class);
 
 		// then
-		assertThat(columns).isEqualTo(
-			"ts.x_tester_id AS x_tester_id,\n"
-				+ "ts.tester_nm AS tester_nm,\n"
-				+ "address.x_state AS adr_x_state,\n"
-				+ "address.cty AS adr_cty");
+		assertThat(columns).contains(
+			"ts.x_tester_id AS x_tester_id, "
+				+ "address.tester_outer_id AS testInner_tester_outer_id, "
+				+ "ts.tester_nm AS tester_nm, "
+				+ "address.cty AS testInner_cty, "
+				+ "address.x_state AS testInner_x_state, "
+				+ "ts.adr_cty AS adr_cty, "
+				+ "ts.adr_x_state AS adr_x_state");
 	}
 
-	// @SqlTableAlias("ts")
+	@SqlTableAlias("ts")
 	static class TestOuterEntity {
 		private Long testerId;
 
 		@Column("tester_nm")
 		private String testerName;
 
-		// @SqlTableAlias("address")
-		@Embedded.Nullable(prefix = "adr_")
+		@SqlTableAlias("address")
+		@Column("tester_outer_id")
 		private TestInnerEntity testInner;
+
+		@Embedded.Nullable(prefix = "adr_")
+		private TestInnerEntity testInnerEmbedded;
 	}
 
 	static class TestInnerEntity {
@@ -122,7 +224,7 @@ class SqlProviderTest {
 		private String city;
 	}
 
-	// @SqlTableAlias("ts")
+	@SqlTableAlias("ts")
 	static class TestEntityWithNonNullValue {
 		@Column
 		private Long testerId;
@@ -130,29 +232,40 @@ class SqlProviderTest {
 		@Column("tester_nm")
 		private String testerName;
 
+		@SqlFunction(expressions = {SqlFunction.COLUMN_NAME, "0"})
 		@Column
 		private int age;
 	}
 
-	// @SqlTableAlias("ts")
-	static class TestEntityWithIgnoredColumn {
-		private Long testerId;
+	static class TestEntityNoRootTableAlias {
+		private Long rootId;
 
-		@Column("tester_nm")
-		private String testerName;
+		@Column("root_name")
+		private String rootName;
 
-		private String phoneNumber; // This column will be ignored
+		@SqlTableAlias("tOuter")
+		@Column("test_root_id")
+		private TestOuterEntity testOuter;
+
+		@Embedded.Nullable(prefix = "outer_")
+		private TestOuterEntity testOuterEmbedded;
 	}
 
 	@Table("teie")
-	static class TestEmbeddedIgnoreEntity {
-		private Long testerId;
+	static class TestEmbeddedNested {
+		private Long rootId;
 
-		@Column("tester_nm")
-		private String testerName;
+		@Column("root_name")
+		private String rootName;
 
-		@Embedded.Nullable(prefix = "adr_")
-		private TestInnerEntity testInner;
+		@Column("test_root_id")
+		private TestOuterEntity testOuter;
+
+		@Embedded.Nullable(prefix = "outer_")
+		private TestOuterEntity testOuterEmbedded;
+
+		@Embedded.Nullable
+		private TestEntityWithNonNullValue function;
 	}
 
 	private static class PrefixingNamingStrategy implements NamingStrategy {


### PR DESCRIPTION
SQL Column generation 시 `@SqlTableAlias` 가 붙은 속성은 테이블 Alias 를 애노테이션의 값으로 사용해서 생성합니다.
생성 규칙은 테스트를 확인하면 됩니다.


```java
@SqlTableAlias("ts")
class TestOuterEntity {
    private Long testerId;

    @Column("tester_nm")
    private String testerName;

    @SqlTableAlias("address")
    @Column("tester_outer_id")
    private TestInnerEntity testInner;

    @Embedded.Nullable(prefix = "adr_")
    private TestInnerEntity testInnerEmbedded;
}

class TestInnerEntity {
    @Column
    private String state;

    @Column("cty")
    private String city;
}

String columns = sut.columns(TestOuterEntity.class);
// ts.tester_id AS tester_id, 
// address.tester_outer_id AS testInner_tester_outer_id, 
// ts.tester_nm AS tester_nm, 
// address.cty AS testInner_cty,
// address.state AS testInner_state, 
// ts.adr_cty AS adr_cty,
// ts.adr_state AS adr_state

```