### PR TITLE
Apply JSR310 converters with timestamp

### DIFF
--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/DefaultJdbcParameterSourceConverter.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/DefaultJdbcParameterSourceConverter.java
@@ -135,7 +135,7 @@ public class DefaultJdbcParameterSourceConverter implements JdbcParameterSourceC
 	@SuppressWarnings("CollectionAddAllCanBeReplacedWithConstructor")
 	private static Map<Class<?>, Converter<?, ?>> getDefaultConverters() {
 		List<Converter<?, ?>> converters = new ArrayList<>();
-		converters.addAll(Java8TimeParameterTypeConverter.getConvertersToRegister());
+		converters.addAll(Jsr310TimestampBasedConverters.getConvertersToRegister());
 		converters.add(UuidParameterTypeConverter.UuidToStringTypeConverter.INSTANCE);
 		return converters.stream()
 			.collect(toMap(c -> resolveConverterGenerics(c.getClass()).get(0), c -> c));

--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/Java8TimeParameterTypeConverter.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/Java8TimeParameterTypeConverter.java
@@ -34,7 +34,9 @@ import org.springframework.core.convert.converter.Converter;
  * The type Java 8 time parameter type converter.
  *
  * @author Myeonghyeon Lee
+ * @deprecated use {@link Jsr310TimestampBasedConverters}
  */
+@Deprecated
 public class Java8TimeParameterTypeConverter {
 	/**
 	 * Gets converters to register.

--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/Jsr310TimestampBasedConverters.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/Jsr310TimestampBasedConverters.java
@@ -1,0 +1,111 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2021 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.jdbc.plus.support.parametersource.converter;
+
+import static java.time.ZoneId.*;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+
+/**
+ * The type JSR 310 Timestamp based converters.
+ *
+ * @author Myeonghyeon Lee
+ */
+public abstract class Jsr310TimestampBasedConverters {
+
+	/**
+	 * Gets converters to register.
+	 *
+	 * @return the converters to register
+	 */
+	public static List<Converter<?, ?>> getConvertersToRegister() {
+		return Arrays.asList(
+			LocalDateTimeToTimestampConverter.INSTANCE,
+			LocalDateToTimestampConverter.INSTANCE,
+			LocalTimeToTimestampConverter.INSTANCE,
+			InstantToTimestampConverter.INSTANCE,
+			ZonedDateTimeToTimestampConverter.INSTANCE
+		);
+	}
+
+	public enum LocalDateTimeToTimestampConverter implements Converter<LocalDateTime, Timestamp> {
+
+		INSTANCE;
+
+		@NonNull
+		@Override
+		public Timestamp convert(LocalDateTime source) {
+			return Timestamp.from(source.atZone(systemDefault()).toInstant());
+		}
+	}
+
+	public enum LocalDateToTimestampConverter implements Converter<LocalDate, Timestamp> {
+
+		INSTANCE;
+
+		@NonNull
+		@Override
+		public Timestamp convert(LocalDate source) {
+			return Timestamp.from(source.atStartOfDay(systemDefault()).toInstant());
+		}
+	}
+
+	public enum LocalTimeToTimestampConverter implements Converter<LocalTime, Timestamp> {
+
+		INSTANCE;
+
+		@NonNull
+		@Override
+		public Timestamp convert(LocalTime source) {
+			return Timestamp.from(source.atDate(LocalDate.now()).atZone(systemDefault()).toInstant());
+		}
+	}
+
+	public enum InstantToTimestampConverter implements Converter<Instant, Timestamp> {
+
+		INSTANCE;
+
+		@NonNull
+		@Override
+		public Timestamp convert(Instant source) {
+			return Timestamp.from(source);
+		}
+	}
+
+	public enum ZonedDateTimeToTimestampConverter implements Converter<ZonedDateTime, Timestamp> {
+
+		INSTANCE;
+
+		@NonNull
+		@Override
+		public Timestamp convert(ZonedDateTime source) {
+			return Timestamp.from(source.toInstant());
+		}
+	}
+}

--- a/spring-jdbc-plus-support/src/test/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/DefaultJdbcParameterSourceConverterTest.java
+++ b/spring-jdbc-plus-support/src/test/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/DefaultJdbcParameterSourceConverterTest.java
@@ -20,13 +20,13 @@ package com.navercorp.spring.jdbc.plus.support.parametersource.converter;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -64,10 +64,10 @@ class DefaultJdbcParameterSourceConverterTest {
 
 		// then
 		assertThat(str).isEqualTo(":sample:");
-		assertThat(instant).isExactlyInstanceOf(Date.class);
-		assertThat(localDateTime).isExactlyInstanceOf(Date.class);
-		assertThat(localDate).isExactlyInstanceOf(Date.class);
-		assertThat(zonedDateTime).isExactlyInstanceOf(Date.class);
+		assertThat(instant).isExactlyInstanceOf(Timestamp.class);
+		assertThat(localDateTime).isExactlyInstanceOf(Timestamp.class);
+		assertThat(localDate).isExactlyInstanceOf(Timestamp.class);
+		assertThat(zonedDateTime).isExactlyInstanceOf(Timestamp.class);
 		assertThat(enumName).isExactlyInstanceOf(String.class);
 		assertThat(uuid).isExactlyInstanceOf(String.class);
 
@@ -90,7 +90,7 @@ class DefaultJdbcParameterSourceConverterTest {
 	void convertNullValue() {
 		// given
 		DefaultJdbcParameterSourceConverter sut = new DefaultJdbcParameterSourceConverter(
-			Java8TimeParameterTypeConverter.getConvertersToRegister());
+			Jsr310TimestampBasedConverters.getConvertersToRegister());
 		String paramName = "name";
 		Instant value = null;
 
@@ -106,7 +106,7 @@ class DefaultJdbcParameterSourceConverterTest {
 	void convertUnregisteredTypeValue() {
 		// given
 		DefaultJdbcParameterSourceConverter sut = new DefaultJdbcParameterSourceConverter(
-			Java8TimeParameterTypeConverter.getConvertersToRegister());
+			Jsr310TimestampBasedConverters.getConvertersToRegister());
 		String paramName = "name";
 		String value = "sample";
 


### PR DESCRIPTION
SQL ParameterSource 에 적용되는 디폴트 날짜타입(JSR310) 컨버터를 Timestamp 기반 Converter 로 변경합니다.

아래 Spring Data JDBC 커밋에 대한 반영입니다.
https://github.com/spring-projects/spring-data-jdbc/commit/69fe41dd553f962693a6f9af4000f3abe7bcbaf6