### PR TITLE
[#90] Use DmlTable column to make dml query

### DIFF
--- a/guide-projects/plus-sql-java-groovy-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/sql/guide/board/BoardRepositoryTest.java
+++ b/guide-projects/plus-sql-java-groovy-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/sql/guide/board/BoardRepositoryTest.java
@@ -91,18 +91,18 @@ public class BoardRepositoryTest {
 							.build()
 					))
 					.configMap(Stream.of(
-						Config.builder()
-							.configKey("board1 post1 config-key")
-							.configValue("board1 post1 config-value")
-							.build(),
-						Config.builder()
-							.configKey("board1 post1 config-key2")
-							.configValue("board1 post1 config-value2")
-							.build(),
-						Config.builder()
-							.configKey("board1 post1 config-key3")
-							.configValue("board1 post1 config-value3")
-							.build())
+							Config.builder()
+								.configKey("board1 post1 config-key")
+								.configValue("board1 post1 config-value")
+								.build(),
+							Config.builder()
+								.configKey("board1 post1 config-key2")
+								.configValue("board1 post1 config-value2")
+								.build(),
+							Config.builder()
+								.configKey("board1 post1 config-key3")
+								.configValue("board1 post1 config-value3")
+								.build())
 						.collect(toMap(Config::getConfigKey, config -> config)))
 					.audit(Audit.builder()
 						.name("naver1")
@@ -156,14 +156,14 @@ public class BoardRepositoryTest {
 					.build()
 			))
 			.configMap(Stream.of(
-				Config.builder()
-					.configKey("board1 config-key")
-					.configValue("board1 config-value")
-					.build(),
-				Config.builder()
-					.configKey("board1 config-key2")
-					.configValue("board1 config-value2")
-					.build())
+					Config.builder()
+						.configKey("board1 config-key")
+						.configValue("board1 config-value")
+						.build(),
+					Config.builder()
+						.configKey("board1 config-key2")
+						.configValue("board1 config-value2")
+						.build())
 				.collect(toMap(Config::getConfigKey, config -> config)))
 			.audit(Audit.builder()
 				.name("naver")

--- a/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlContext.java
+++ b/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlContext.java
@@ -17,6 +17,7 @@ package com.navercorp.spring.data.jdbc.plus.sql.convert;
 
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.sql.Aliased;
 import org.springframework.data.relational.core.sql.Column;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.data.relational.core.sql.Table;
@@ -58,8 +59,26 @@ class SqlContext implements SqlContexts {
 	}
 
 	@Override
+	public Column getDmlIdColumn() {
+		Table dmlTable = table;
+		if (table instanceof Aliased) {
+			dmlTable = Table.create(table.getName());
+		}
+		return dmlTable.column(entity.getIdColumn());
+	}
+
+	@Override
 	public Column getVersionColumn() {
 		return table.column(entity.getRequiredVersionProperty().getColumnName());
+	}
+
+	@Override
+	public Column getDmlVersionColumn() {
+		Table dmlTable = table;
+		if (table instanceof Aliased) {
+			dmlTable = Table.create(table.getName());
+		}
+		return dmlTable.column(entity.getRequiredVersionProperty().getColumnName());
 	}
 
 	@Override

--- a/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlContexts.java
+++ b/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlContexts.java
@@ -36,6 +36,13 @@ public interface SqlContexts {
 	Column getIdColumn();
 
 	/**
+	 * Gets dml id column for dml.
+	 *
+	 * @return the id column
+	 */
+	Column getDmlIdColumn();
+
+	/**
 	 * Gets table.
 	 *
 	 * @return the table
@@ -64,6 +71,13 @@ public interface SqlContexts {
 	 * @return the version column
 	 */
 	Column getVersionColumn();
+
+	/**
+	 * Gets version column for dml.
+	 *
+	 * @return the version column
+	 */
+	Column getDmlVersionColumn();
 
 	/**
 	 * Gets reverse column.

--- a/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlGenerator.java
+++ b/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlGenerator.java
@@ -884,8 +884,7 @@ class SqlGenerator {
 	private String createUpdateWithVersionSql() {
 
 		Update update = createBaseUpdate() //
-			.and(getVersionColumn().isEqualTo(
-				getBindMarker(VERSION_SQL_PARAMETER))) //
+			.and(getDmlVersionColumn().isEqualTo(getBindMarker(VERSION_SQL_PARAMETER))) //
 			.build();
 
 		return render(update);
@@ -900,12 +899,12 @@ class SqlGenerator {
 			.map(columnName -> Assignments.value( //
 				table.column(columnName), //
 				getBindMarker(columnName))) //
-			.collect(Collectors.toList());
+			.toList();
 
 		return Update.builder() //
 			.table(table) //
 			.set(assignments) //
-			.where(getIdColumn().isEqualTo(getBindMarker(entity.getIdColumn())));
+			.where(getDmlIdColumn().isEqualTo(getBindMarker(entity.getIdColumn())));
 	}
 
 	private String createUpsertSql() {
@@ -947,7 +946,7 @@ class SqlGenerator {
 	private String createDeleteByIdAndVersionSql() {
 
 		Delete delete = createBaseDeleteById(getDmlTable()) //
-			.and(getVersionColumn().isEqualTo(
+			.and(getDmlVersionColumn().isEqualTo(
 				getBindMarker(VERSION_SQL_PARAMETER))) //
 			.build();
 
@@ -956,14 +955,14 @@ class SqlGenerator {
 
 	private DeleteBuilder.DeleteWhereAndOr createBaseDeleteById(Table table) {
 		return Delete.builder().from(table)
-			.where(getIdColumn().isEqualTo(
+			.where(getDmlIdColumn().isEqualTo(
 				getBindMarker(ID_SQL_PARAMETER)));
 	}
 
 	private DeleteBuilder.DeleteWhereAndOr createBaseDeleteByIdIn(Table table) {
 
 		return Delete.builder().from(table)
-			.where(getIdColumn().in(getBindMarker(IDS_SQL_PARAMETER)));
+			.where(getDmlIdColumn().in(getBindMarker(IDS_SQL_PARAMETER)));
 	}
 
 	private String createDeleteByPathAndCriteria(PersistentPropertyPathExtension path,
@@ -997,7 +996,7 @@ class SqlGenerator {
 
 		Delete delete = Delete.builder() //
 			.from(table) //
-			.where(getIdColumn().in(getBindMarker(IDS_SQL_PARAMETER))) //
+			.where(getDmlIdColumn().in(getBindMarker(IDS_SQL_PARAMETER))) //
 			.build();
 
 		return render(delete);
@@ -1036,8 +1035,16 @@ class SqlGenerator {
 		return sqlContext.getIdColumn();
 	}
 
+	private Column getDmlIdColumn() {
+		return sqlContext.getDmlIdColumn();
+	}
+
 	private Column getVersionColumn() {
 		return sqlContext.getVersionColumn();
+	}
+
+	private Column getDmlVersionColumn() {
+		return sqlContext.getDmlVersionColumn();
 	}
 
 	private String renderReference(SqlIdentifier identifier) {

--- a/spring-data-jdbc-plus-sql/src/test/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlGeneratorTest.java
+++ b/spring-data-jdbc-plus-sql/src/test/java/com/navercorp/spring/data/jdbc/plus/sql/convert/SqlGeneratorTest.java
@@ -31,9 +31,12 @@ import org.springframework.data.relational.core.mapping.PersistentPropertyPathEx
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.data.relational.core.sql.Aliased;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.data.relational.core.sql.TableLike;
+
+import com.navercorp.spring.data.jdbc.plus.sql.annotation.SqlTableAlias;
 
 /**
  * COPY org.springframework.data.relational.core.convert.SqlGeneratorUnitTests
@@ -753,6 +756,31 @@ class SqlGeneratorTest {
 				quoted("child"), quoted("CHILD_PARENT_OF_NO_ID_CHILD"));
 	}
 
+	@Test
+	void updateWithAlias() {
+
+		assertThat(createSqlGenerator(DummyAliasEntity.class, NonQuotingDialect.INSTANCE).getUpdate())
+			.contains("WHERE dummy_entity.id1 = :id1");
+	}
+
+	@Test
+	void deleteWithAlias() {
+		assertThat(createSqlGenerator(DummyAliasEntity.class, NonQuotingDialect.INSTANCE).getDeleteById())
+			.contains("WHERE dummy_entity.id1 = :id");
+	}
+
+	@Test
+	void updateVersionWithAlias() {
+		assertThat(createSqlGenerator(VersionedAliasEntity.class, NonQuotingDialect.INSTANCE).getUpdateWithVersion())
+			.contains("WHERE versioned_entity.id1 = :id1 AND versioned_entity.x_version = :___old");
+	}
+
+	@Test
+	void deleteVersionWithAlias() {
+		assertThat(createSqlGenerator(VersionedAliasEntity.class, NonQuotingDialect.INSTANCE).getDeleteByIdAndVersion())
+			.contains("versioned_entity.id1 = :id AND versioned_entity.x_version = :___old");
+	}
+
 	private SqlIdentifier getAlias(Object maybeAliased) {
 
 		if (maybeAliased instanceof Aliased) {
@@ -785,6 +813,30 @@ class SqlGeneratorTest {
 		Set<Element> elements;
 		Map<Integer, Element> mappedElements;
 		AggregateReference<OtherAggregate, Long> other;
+	}
+
+	@SuppressWarnings("unused")
+	@Table("dummy_entity")
+	@SqlTableAlias("n_dummy")
+	static class DummyAliasEntity {
+
+		@Column("id1")
+		@Id
+		Long id;
+		String name;
+		ReferencedEntity ref;
+		Set<Element> elements;
+		Map<Integer, Element> mappedElements;
+		AggregateReference<OtherAggregate, Long> other;
+	}
+
+	@SuppressWarnings("unused")
+	@Table("versioned_entity")
+	@SqlTableAlias("n_dummy")
+	static class VersionedAliasEntity extends DummyAliasEntity {
+
+		@Version
+		Integer version;
 	}
 
 	static class VersionedEntity extends DummyEntity {


### PR DESCRIPTION
`@TableAlias` 를 사용한 DML Query 시

```JAVA
@TableAlias("n_bd")
public class Board {
...
}
```

```SQL
UPDATE n_board
...
WHERE n_bd.id = :id;
```

위 형태로 쿼리가 수정되어 `n_bd` Table Not Found Exception 이 일어나는 버그를 수정합니다.


