### PR TITLE
[#94] Add array padding option

### DIFF
--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleMapSqlParameterSource.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleMapSqlParameterSource.java
@@ -32,11 +32,13 @@ import com.navercorp.spring.jdbc.plus.support.parametersource.fallback.FallbackP
  * The type Convertible map sql parameter source.
  *
  * @author Myeonghyeon Lee
+ * @author IAM20
  */
 public class ConvertibleMapSqlParameterSource extends MapSqlParameterSource {
 	private final JdbcParameterSourceConverter converter;
 	private final FallbackParameterSource fallbackParameterSource;
 
+	private boolean padArray = true;
 	private boolean paddingIterableParams = false;
 	private int[] paddingIterableBoundaries = null;
 
@@ -85,7 +87,7 @@ public class ConvertibleMapSqlParameterSource extends MapSqlParameterSource {
 
 		value = this.converter.convert(paramName, value);
 		if (this.paddingIterableParams) {
-			value = IterableExpandPadding.expandIfIterable(value, this.paddingIterableBoundaries);
+			value = IterableExpandPadding.expandIfIterable(value, this.padArray, this.paddingIterableBoundaries);
 		}
 
 		return value;
@@ -98,6 +100,15 @@ public class ConvertibleMapSqlParameterSource extends MapSqlParameterSource {
 	 */
 	public void setPaddingIterableBoundaries(int[] setPaddingIterableBoundaries) {
 		this.paddingIterableBoundaries = setPaddingIterableBoundaries;
+	}
+
+	/**
+	 * Sets pad array.
+	 *
+	 * @param padArray the pad array y/n
+	 */
+	public void setPadArray(boolean padArray) {
+		this.padArray = padArray;
 	}
 
 	/**

--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleParameterSourceFactory.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleParameterSourceFactory.java
@@ -36,6 +36,7 @@ public class ConvertibleParameterSourceFactory {
 	private final JdbcParameterSourceConverter converter;
 	private final FallbackParameterSource fallbackParameterSource;
 
+	private boolean padArray = true;
 	private boolean paddingIterableParams = false;
 	private int[] paddingIterableBoundaries = null;
 
@@ -101,6 +102,7 @@ public class ConvertibleParameterSourceFactory {
 			new ConvertibleMapSqlParameterSource(map, this.converter, this.fallbackParameterSource);
 		paramSource.setPaddingIterableParam(this.paddingIterableParams);
 		paramSource.setPaddingIterableBoundaries(this.paddingIterableBoundaries);
+		paramSource.setPadArray(this.padArray);
 		return paramSource;
 	}
 

--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/IterableExpandPadding.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/IterableExpandPadding.java
@@ -30,6 +30,7 @@ import org.springframework.lang.Nullable;
  * The type Iterable expand padding.
  *
  * @author Myeonghyeon Lee
+ * @author IAM20
  */
 public class IterableExpandPadding {
 	private static final int[] REGULAR_SIZES = {0, 1, 2, 3, 4, 8, 16, 32, 50, 100, 200, 300, 500, 1000, 1500, 2000};
@@ -52,6 +53,18 @@ public class IterableExpandPadding {
 	 * @return the object
 	 */
 	public static Object expandIfIterable(Object source, @Nullable int[] paddingBoundaries) {
+		return expandIfIterable(source, true, paddingBoundaries);
+	}
+
+	/**
+	 * Expand if iterable object.
+	 *
+	 * @param source            the source
+	 * @param padArray          the pad array y/n
+	 * @param paddingBoundaries the padding boundaries
+	 * @return the object
+	 */
+	public static Object expandIfIterable(Object source, boolean padArray, @Nullable int[] paddingBoundaries) {
 		if (source == null) {
 			return null;
 		}
@@ -62,7 +75,7 @@ public class IterableExpandPadding {
 
 		if (source instanceof Collection) {
 			return CollectionExpandPadding.INSTANCE.expand((Collection<?>)source, paddingBoundaries);
-		} else if (source.getClass().isArray()) {
+		} else if (source.getClass().isArray() && padArray) {
 			return ArrayExpandPadding.INSTANCE.expand((Object[])source, paddingBoundaries);
 		}
 

--- a/spring-jdbc-plus-support/src/test/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/DefaultJdbcParameterSourceConverterTest.java
+++ b/spring-jdbc-plus-support/src/test/java/com/navercorp/spring/jdbc/plus/support/parametersource/converter/DefaultJdbcParameterSourceConverterTest.java
@@ -430,7 +430,7 @@ class DefaultJdbcParameterSourceConverterTest {
 			if (value instanceof JsonArray) {
 				return new JsonArray("conditional unwrapped " + value.value);
 			} else if (value instanceof JsonValue) {
-					return new JsonValue("conditional unwrapped " + value.value);
+				return new JsonValue("conditional unwrapped " + value.value);
 			} else {
 				return new JsonNode("conditional unwrapped " + value.value);
 			}


### PR DESCRIPTION
`byte[]` `int[]` 와 같이 primitive type array 에서는 패딩되지 않는 것이 좀 더 의도된 동작일 가능성이 높습니다.
이에 array 의 경우 padding 되지 않도록 하는 option 을 추가합니다.

----

In the case of the primary type arrays like `byte[]` `int[]` ... etc.. it may be a more intended operation not to be padded.

Support  array padding option will be better for using primitive type usage.