### PR TITLE
[#94] Add padArrayYn getter in convertibleParameterSourceFactory

### DIFF
--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleParameterSourceFactory.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleParameterSourceFactory.java
@@ -154,6 +154,15 @@ public class ConvertibleParameterSourceFactory {
 	}
 
 	/**
+	 * Is pad array boolean.
+	 *
+	 * @return the boolean
+	 */
+	public boolean isPadArray() {
+		return padArray;
+	}
+
+	/**
 	 * Gets converter.
 	 *
 	 * @return the converter


### PR DESCRIPTION
`padArrayYn` 도 paddingIterableBoundaries 처럼 getter 를 추가합니다.

---

Adds a padArrayYn getter like paddingIterableBoundaries.