### PR TITLE
Add architecture diagrams link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/naver/spring-jdbc-plus.svg)](https://img.shields.io/github/v/release/naver/spring-jdbc-plus.svg?include_prereleases)
 [![GitHub license](https://img.shields.io/github/license/naver/spring-jdbc-plus.svg)](https://github.com/naver/spring-jdbc-plus.js/blob/master/LICENSE)
 
-# Spring JDBC Plus ![build](https://github.com/naver/spring-jdbc-plus/workflows/build/badge.svg) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/naver/spring-jdbc-plus)
+# Spring JDBC Plus ![build](https://github.com/naver/spring-jdbc-plus/workflows/build/badge.svg) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/naver/spring-jdbc-plus) [![Project Diagrams](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/naverspringjdbcplus/)
 
 Spring JDBC Plus provides [Spring Data JDBC](https://github.com/spring-projects/spring-data-relational) based extension.
 It provides necessary features when writing more complex SQL than the functions supported by `CrudRepository`.


### PR DESCRIPTION
Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/naverspringjdbcplus/). Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project.

In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful!