### PR TITLE
[#112] Deprecate pad array option

### DIFF
--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleBeanPropertySqlParameterSource.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleBeanPropertySqlParameterSource.java
@@ -170,7 +170,9 @@ public class ConvertibleBeanPropertySqlParameterSource extends BeanPropertySqlPa
 	 * Sets pad array.
 	 *
 	 * @param padArray the pad array y/n
+	 * @deprecated No plans to replacement
 	 */
+	@Deprecated
 	public void setPadArray(boolean padArray) {
 		this.padArray = padArray;
 	}

--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleMapSqlParameterSource.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleMapSqlParameterSource.java
@@ -38,7 +38,7 @@ public class ConvertibleMapSqlParameterSource extends MapSqlParameterSource {
 	private final JdbcParameterSourceConverter converter;
 	private final FallbackParameterSource fallbackParameterSource;
 
-	private boolean padArray = true;
+	private boolean padArray = false;
 	private boolean paddingIterableParams = false;
 	private int[] paddingIterableBoundaries = null;
 
@@ -110,7 +110,9 @@ public class ConvertibleMapSqlParameterSource extends MapSqlParameterSource {
 	 * Sets pad array.
 	 *
 	 * @param padArray the pad array y/n
+	 * @deprecated No plan to replacement
 	 */
+	@Deprecated
 	public void setPadArray(boolean padArray) {
 		this.padArray = padArray;
 	}

--- a/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleParameterSourceFactory.java
+++ b/spring-jdbc-plus-support/src/main/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleParameterSourceFactory.java
@@ -36,7 +36,7 @@ public class ConvertibleParameterSourceFactory {
 	private final JdbcParameterSourceConverter converter;
 	private final FallbackParameterSource fallbackParameterSource;
 
-	private boolean padArray = true;
+	private boolean padArray = false;
 	private boolean paddingIterableParams = false;
 	private int[] paddingIterableBoundaries = null;
 
@@ -148,7 +148,9 @@ public class ConvertibleParameterSourceFactory {
 	 * Sets pad array.
 	 *
 	 * @param padArray the pad array y/n
+	 * @deprecated No plans to replacement
 	 */
+	@Deprecated(forRemoval = true, since = "3.2")
 	public void setPadArray(boolean padArray) {
 		this.padArray = padArray;
 	}
@@ -157,7 +159,9 @@ public class ConvertibleParameterSourceFactory {
 	 * Is pad array boolean.
 	 *
 	 * @return the boolean
+	 * @deprecated No plans to replacement
 	 */
+	@Deprecated(forRemoval = true, since = "3.2")
 	public boolean isPadArray() {
 		return padArray;
 	}

--- a/spring-jdbc-plus-support/src/test/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleBeanPropertySqlParameterSourceTest.java
+++ b/spring-jdbc-plus-support/src/test/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleBeanPropertySqlParameterSourceTest.java
@@ -226,7 +226,6 @@ class ConvertibleBeanPropertySqlParameterSourceTest {
 		ConvertibleBeanPropertySqlParameterSource sut =
 			new ConvertibleBeanPropertySqlParameterSource(criteria, this.converter);
 		sut.setPaddingIterableParam(true);
-		sut.setPadArray(true);
 
 		// when
 		Object actual = sut.getValue("list");
@@ -254,7 +253,6 @@ class ConvertibleBeanPropertySqlParameterSourceTest {
 			new ConvertibleBeanPropertySqlParameterSource(criteria, this.converter);
 		sut.setPaddingIterableBoundaries(new int[] {1, 10});
 		sut.setPaddingIterableParam(false);
-		sut.setPadArray(true);
 
 		// when
 		Object actual = sut.getValue("list");

--- a/spring-jdbc-plus-support/src/test/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleMapSqlParameterSourceTest.java
+++ b/spring-jdbc-plus-support/src/test/java/com/navercorp/spring/jdbc/plus/support/parametersource/ConvertibleMapSqlParameterSourceTest.java
@@ -143,7 +143,6 @@ class ConvertibleMapSqlParameterSourceTest {
 		Map<String, Object> map = Collections.singletonMap(paramName, value);
 		ConvertibleMapSqlParameterSource sut = new ConvertibleMapSqlParameterSource(map, this.converter);
 		sut.setPaddingIterableParam(true);
-		sut.setPadArray(true);
 
 		// when
 		Object actual = sut.getValue(paramName);
@@ -158,57 +157,6 @@ class ConvertibleMapSqlParameterSourceTest {
 			InstantToTimestampConverter.INSTANCE.convert(value.get(4)));
 		assertThat(list.get(7)).isEqualTo(
 			InstantToTimestampConverter.INSTANCE.convert(value.get(4)));
-	}
-
-	@DisplayName("Array 는 expand padding flag 가 false 면 padding 을 수행하지 않는다.")
-	@ParameterizedTest
-	@AutoSource
-	@SuppressWarnings("unchecked")
-	void getValueIterablePaddingForArray(String paramName) {
-		// given
-		Instant now = Instant.now();
-		Instant[] value = {now.minusSeconds(300), now.minusSeconds(240),
-			now.minusSeconds(180), now.minusSeconds(120), now.minusSeconds(60)};
-		Map<String, Object> map = Collections.singletonMap(paramName, value);
-		ConvertibleMapSqlParameterSource sut = new ConvertibleMapSqlParameterSource(map, this.converter);
-		sut.setPaddingIterableParam(true);
-		sut.setPadArray(false);
-
-		// when
-		Object actual = sut.getValue(paramName);
-
-		// then
-		assertThat(actual).isInstanceOf(Object[].class);
-		Object[] array = (Object[])actual;
-		assertThat(array).hasSize(5);
-		assertThat(array[0]).isEqualTo(
-			InstantToTimestampConverter.INSTANCE.convert(value[0]));
-		assertThat(array[4]).isEqualTo(
-			InstantToTimestampConverter.INSTANCE.convert(value[4]));
-	}
-
-	@DisplayName("iterablePaddingBoundaries 를 주입하더라도 paddingIterableParam 이 false 면 padding 하지 않는다.")
-	@ParameterizedTest
-	@AutoSource
-	@SuppressWarnings("unchecked")
-	void getValueIterablePaddingBoundariesButFalse(String paramName) {
-		// given
-		Instant now = Instant.now();
-		List<Instant> value = Arrays.asList(now.minusSeconds(300), now.minusSeconds(240),
-			now.minusSeconds(180), now.minusSeconds(120), now.minusSeconds(60));
-		Map<String, Object> map = Collections.singletonMap(paramName, value);
-		ConvertibleMapSqlParameterSource sut = new ConvertibleMapSqlParameterSource(map, this.converter);
-		sut.setPaddingIterableBoundaries(new int[] {1, 10});
-		sut.setPaddingIterableParam(false);
-		sut.setPadArray(true);
-
-		// when
-		Object actual = sut.getValue(paramName);
-
-		// then
-		assertThat(actual).isInstanceOf(List.class);
-		List<Timestamp> list = (List<Timestamp>)actual;
-		assertThat(list).hasSize(5);
 	}
 
 	static class TestFallbackParamSource implements FallbackParameterSource {


### PR DESCRIPTION
Deprecate pad array option

Padding primitive type array such as `byte[]` is not expected case as usual.
I think it's a little more intuitive to deprecate whole array, rather than primitive type array.
So we deprecate `padArray` options.

--------

Primitive type array padding 은 보통 예상되는 행동이 아닙니다.
선별적인 것 보다 Array 인 경우에는 Padding 하지 않도록 변경하는 것이
조금 더 직관적이라 생각해서 `Deprecated` 처리합니다.
