### PR TITLE
[#121] Remove redundant reimplemenetation

### DIFF
--- a/spring-data-jdbc-plus-repository/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/support/JdbcPlusRepositoryFactory.java
+++ b/spring-data-jdbc-plus-repository/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/support/JdbcPlusRepositoryFactory.java
@@ -19,15 +19,11 @@
 package com.navercorp.spring.data.jdbc.plus.repository.support;
 
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
-import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
-import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
-import org.springframework.data.repository.core.RepositoryInformation;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 
@@ -39,11 +35,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
  * {@link JdbcRepositoryFactory}
  */
 public class JdbcPlusRepositoryFactory extends JdbcRepositoryFactory {
-	private final RelationalMappingContext context;
-	private final JdbcConverter converter;
-	private final ApplicationEventPublisher publisher;
-	private final DataAccessStrategy accessStrategy;
-	private EntityCallbacks entityCallbacks;
 
 	/**
 	 * Instantiates a new Jdbc plus repository factory.
@@ -61,41 +52,13 @@ public class JdbcPlusRepositoryFactory extends JdbcRepositoryFactory {
 		JdbcConverter converter,
 		Dialect dialect,
 		ApplicationEventPublisher publisher,
-		NamedParameterJdbcOperations operations) {
-
+		NamedParameterJdbcOperations operations
+	) {
 		super(dataAccessStrategy, context, converter, dialect, publisher, operations);
-		this.context = context;
-		this.converter = converter;
-		this.publisher = publisher;
-		this.accessStrategy = dataAccessStrategy;
-	}
-
-	@Override
-	protected Object getTargetRepository(RepositoryInformation repositoryInformation) {
-
-		JdbcAggregateTemplate template = new JdbcAggregateTemplate(
-			publisher, context, converter, accessStrategy);
-
-		if (entityCallbacks != null) {
-			template.setEntityCallbacks(entityCallbacks);
-		}
-
-		RelationalPersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(
-			repositoryInformation.getDomainTypeInformation()
-		);
-
-		return getTargetRepositoryViaReflection(repositoryInformation, template, persistentEntity,
-			converter);
 	}
 
 	@Override
 	protected Class<?> getRepositoryBaseClass(RepositoryMetadata repositoryMetadata) {
 		return JdbcPlusRepository.class;
-	}
-
-	@Override
-	public void setEntityCallbacks(EntityCallbacks entityCallbacks) {
-		this.entityCallbacks = entityCallbacks;
-		super.setEntityCallbacks(entityCallbacks);
 	}
 }


### PR DESCRIPTION
`JdbcPlusRepositoryFactory` is exactly equal to `JdbcRepositoryFactory` except `getRepositoryBaseClass` method.
Thus we remove redundant reimplementation