### PR TITLE
Replace manual spring-data version to spring-data-bom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,11 @@ subprojects {
 
     dependencyManagement {
         imports {
-            mavenBom SpringBootPlugin.BOM_COORDINATES
+            mavenBom("${SpringBootPlugin.BOM_COORDINATES}") {
+                bomProperties([
+                        'spring-data-bom.version': "${springDataBomVersion}"
+                ])
+            }
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
-springDataVersion=3.3.0-M2
-springDataCommonsVersion=3.3.0-M2
 springBootVersion=3.3.0-M2
+springDataBomVersion=2024.0.0-M2
 kotlinVersion=1.9.20

--- a/guide-projects/plus-repository-guide/build.gradle
+++ b/guide-projects/plus-repository-guide/build.gradle
@@ -6,9 +6,9 @@ dependencies {
     implementation("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
-    implementation("org.springframework.data:spring-data-jdbc:${springDataVersion}")
-    implementation("org.springframework.data:spring-data-relational:${springDataVersion}")
-    implementation("org.springframework.data:spring-data-commons:${springDataCommonsVersion}")
+    implementation("org.springframework.data:spring-data-jdbc")
+    implementation("org.springframework.data:spring-data-relational")
+    implementation("org.springframework.data:spring-data-commons")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.projectlombok:lombok")

--- a/guide-projects/plus-sql-java-groovy-guide/build.gradle
+++ b/guide-projects/plus-sql-java-groovy-guide/build.gradle
@@ -40,15 +40,15 @@ dependencies {
     implementation('org.codehaus.groovy:groovy:3.0.13')
     implementation("com.h2database:h2")
 
-    implementation("org.springframework.data:spring-data-jdbc:${springDataVersion}")
-    implementation("org.springframework.data:spring-data-relational:${springDataVersion}")
-    implementation("org.springframework.data:spring-data-commons:${springDataCommonsVersion}")
+    implementation("org.springframework.data:spring-data-jdbc")
+    implementation("org.springframework.data:spring-data-relational")
+    implementation("org.springframework.data:spring-data-commons")
 
     implementation project(":spring-data-plus-sql-gen")
     annotationProcessor project(":spring-data-plus-sql-gen")
-    annotationProcessor("org.springframework.data:spring-data-jdbc:${springDataVersion}")
-    annotationProcessor("org.springframework.data:spring-data-relational:${springDataVersion}")
-    annotationProcessor("org.springframework.data:spring-data-commons:${springDataCommonsVersion}")
+    annotationProcessor("org.springframework.data:spring-data-jdbc")
+    annotationProcessor("org.springframework.data:spring-data-relational")
+    annotationProcessor("org.springframework.data:spring-data-commons")
 
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/guide-projects/plus-sql-java-kotlin-guide/build.gradle
+++ b/guide-projects/plus-sql-java-kotlin-guide/build.gradle
@@ -39,9 +39,9 @@ dependencies {
     implementation("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 
-    implementation("org.springframework.data:spring-data-jdbc:${springDataVersion}")
-    implementation("org.springframework.data:spring-data-relational:${springDataVersion}")
-    implementation("org.springframework.data:spring-data-commons:${springDataCommonsVersion}")
+    implementation("org.springframework.data:spring-data-jdbc")
+    implementation("org.springframework.data:spring-data-relational")
+    implementation("org.springframework.data:spring-data-commons")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.projectlombok:lombok")

--- a/guide-projects/plus-sql-kotlin-guide/build.gradle.kts
+++ b/guide-projects/plus-sql-kotlin-guide/build.gradle.kts
@@ -22,8 +22,6 @@ repositories {
 }
 
 dependencies {
-    val springDataVersion: String by rootProject.extra
-    val springDataCommonsVersion: String by rootProject.extra
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation(project(":spring-boot-starter-data-jdbc-plus-sql"))
@@ -32,9 +30,9 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.h2database:h2")
 
-    implementation("org.springframework.data:spring-data-jdbc:$springDataVersion")
-    implementation("org.springframework.data:spring-data-relational:$springDataVersion")
-    implementation("org.springframework.data:spring-data-commons:$springDataCommonsVersion")
+    implementation("org.springframework.data:spring-data-jdbc")
+    implementation("org.springframework.data:spring-data-relational")
+    implementation("org.springframework.data:spring-data-commons")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/spring-boot-autoconfigure-data-jdbc-plus/build.gradle
+++ b/spring-boot-autoconfigure-data-jdbc-plus/build.gradle
@@ -6,9 +6,9 @@ dependencies {
     implementation project(":spring-data-jdbc-plus-sql")
     implementation project(":spring-data-jdbc-plus-repository")
 
-    implementation("org.springframework.data:spring-data-jdbc:$springDataVersion")
-    implementation("org.springframework.data:spring-data-relational:$springDataVersion")
-    implementation("org.springframework.data:spring-data-commons:$springDataCommonsVersion")
+    implementation("org.springframework.data:spring-data-jdbc")
+    implementation("org.springframework.data:spring-data-relational")
+    implementation("org.springframework.data:spring-data-commons")
     implementation("io.projectreactor:reactor-core")
 
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/spring-boot-starter-data-jdbc-plus-repository/build.gradle
+++ b/spring-boot-starter-data-jdbc-plus-repository/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     api(project(":spring-boot-autoconfigure-data-jdbc-plus"))
     api("org.springframework.boot:spring-boot-starter-jdbc")
 
-    implementation("org.springframework.data:spring-data-jdbc:${springDataVersion}")
-    implementation("org.springframework.data:spring-data-relational:${springDataVersion}")
-    implementation("org.springframework.data:spring-data-commons:${springDataCommonsVersion}")
+    implementation("org.springframework.data:spring-data-jdbc")
+    implementation("org.springframework.data:spring-data-relational")
+    implementation("org.springframework.data:spring-data-commons")
 }

--- a/spring-boot-starter-data-jdbc-plus-sql/build.gradle
+++ b/spring-boot-starter-data-jdbc-plus-sql/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     api(project(":spring-data-jdbc-plus-sql"))
     api("org.springframework.boot:spring-boot-starter-jdbc")
 
-    implementation("org.springframework.data:spring-data-jdbc:${springDataVersion}")
-    implementation("org.springframework.data:spring-data-relational:${springDataVersion}")
-    implementation("org.springframework.data:spring-data-commons:${springDataCommonsVersion}")
+    implementation("org.springframework.data:spring-data-jdbc")
+    implementation("org.springframework.data:spring-data-relational")
+    implementation("org.springframework.data:spring-data-commons")
 }

--- a/spring-data-jdbc-plus-repository/build.gradle
+++ b/spring-data-jdbc-plus-repository/build.gradle
@@ -1,9 +1,9 @@
 compileJava.dependsOn(processResources)
 
 dependencies {
-    api("org.springframework.data:spring-data-jdbc:${springDataVersion}")
-    api("org.springframework.data:spring-data-relational:${springDataVersion}")
-    api("org.springframework.data:spring-data-commons:${springDataCommonsVersion}")
+    api("org.springframework.data:spring-data-jdbc")
+    api("org.springframework.data:spring-data-relational")
+    api("org.springframework.data:spring-data-commons")
 
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.junit.jupiter:junit-jupiter-api")

--- a/spring-data-jdbc-plus-sql/build.gradle
+++ b/spring-data-jdbc-plus-sql/build.gradle
@@ -2,9 +2,9 @@ compileJava.dependsOn(processResources)
 
 dependencies {
     api(project(":spring-jdbc-plus-support"))
-    api("org.springframework.data:spring-data-jdbc:${springDataVersion}")
-    api("org.springframework.data:spring-data-relational:${springDataVersion}")
-    api("org.springframework.data:spring-data-commons:${springDataCommonsVersion}")
+    api("org.springframework.data:spring-data-jdbc")
+    api("org.springframework.data:spring-data-relational")
+    api("org.springframework.data:spring-data-commons")
 
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
     compileOnly("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")

--- a/spring-data-plus-sql-gen/build.gradle
+++ b/spring-data-plus-sql-gen/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     api(project(":spring-data-jdbc-plus-sql"))
 
-    api("org.springframework.data:spring-data-relational:${springDataVersion}")
-    api("org.springframework.data:spring-data-commons:${springDataCommonsVersion}")
+    api("org.springframework.data:spring-data-relational")
+    api("org.springframework.data:spring-data-commons")
     api("com.squareup:javapoet:1.12.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter")


### PR DESCRIPTION
#138 모듈 분리 작업 전 의존성 버전 통합 작업이 필요하여 먼저 반영합니다

### 현재

3.2.3 (spring-boot-bom), 3.3.0-M2 (spring-data) 버전 혼재

### 변경

spring-data-bom

### Reference

- https://docs.spring.io/spring-boot/docs/3.3.0-M2/reference/html/dependency-versions.html#appendix.dependency-versions
- https://github.com/spring-projects/spring-data-bom/releases/tag/2a24.0.0-M2
- https://docs.spring.io/dependency-management-plugin/docs/current/reference/html/#dependency-management-configuration-bom-import-override-property