### PR TITLE
Add soft delete configuration

### DIFF
--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/BooleanStateArticle.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/BooleanStateArticle.java
@@ -1,0 +1,29 @@
+package com.navercorp.spring.data.jdbc.plus.repository.guide.article;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import com.navercorp.spring.jdbc.plus.commons.annotations.SoftDeleteColumn;
+
+@Table("boolean_state_articles")
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class BooleanStateArticle {
+
+	@Id
+	private final Long id;
+	private final String writerId;
+	private final String contents;
+	private final Instant createdAt;
+	private final Instant lastModifiedAt;
+
+	@SoftDeleteColumn.Boolean(valueAsDeleted = "false")
+	private final boolean visible;
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/BooleanStateArticleRepository.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/BooleanStateArticleRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.repository.guide.article;
+
+import com.navercorp.spring.data.jdbc.plus.repository.JdbcRepository;
+import com.navercorp.spring.data.jdbc.plus.repository.guide.order.Order;
+
+/**
+ * @author Chanhyeong Cho
+ */
+public interface BooleanStateArticleRepository extends JdbcRepository<BooleanStateArticle, Long> {
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/EnumStateArticle.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/EnumStateArticle.java
@@ -1,0 +1,50 @@
+package com.navercorp.spring.data.jdbc.plus.repository.guide.article;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import com.navercorp.spring.jdbc.plus.commons.annotations.SoftDeleteColumn;
+
+@Table("enum_state_articles")
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class EnumStateArticle {
+
+	@Id
+	private final Long id;
+	private final String writerId;
+	private final String contents;
+	private final Instant createdAt;
+	private final Instant lastModifiedAt;
+
+	@Version
+	private final int version;
+
+	@SoftDeleteColumn.String(valueAsDeleted = "CLOSE")
+	@Column("article_state")
+	private final State state;
+
+	public boolean closed() {
+		return state == State.CLOSE;
+	}
+
+	@Getter
+	public enum State {
+		OPEN("op"), CLOSE("cl");
+
+		private final String code;
+
+		State(String code) {
+			this.code = code;
+		}
+	}
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/EnumStateArticleRepository.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/EnumStateArticleRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.repository.guide.article;
+
+import com.navercorp.spring.data.jdbc.plus.repository.JdbcRepository;
+
+/**
+ * @author Chanhyeong Cho
+ */
+public interface EnumStateArticleRepository extends JdbcRepository<EnumStateArticle, Long> {
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/config/JdbcConfiguration.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/config/JdbcConfiguration.java
@@ -1,0 +1,44 @@
+package com.navercorp.spring.data.jdbc.plus.repository.guide.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
+
+import com.navercorp.spring.data.jdbc.plus.repository.config.AbstractJdbcPlusConfiguration;
+import com.navercorp.spring.data.jdbc.plus.repository.guide.article.EnumStateArticle;
+import com.navercorp.spring.data.jdbc.plus.repository.guide.article.EnumStateArticle.State;
+
+@Configuration
+public class JdbcConfiguration extends AbstractJdbcPlusConfiguration {
+
+	@Override
+	protected List<?> userConverters() {
+		return List.of(
+			new ArticleStateReadingConverter(),
+			new ArticleStateWritingConverter()
+		);
+	}
+
+	@WritingConverter
+	private static class ArticleStateWritingConverter implements Converter<EnumStateArticle.State, String> {
+		@Override
+		public String convert(EnumStateArticle.State source) {
+			return source.getCode();
+		}
+	}
+
+	@ReadingConverter
+	private static class ArticleStateReadingConverter implements Converter<String, EnumStateArticle.State> {
+		@Override
+		public State convert(String source) {
+			return Arrays.stream(EnumStateArticle.State.values())
+				.filter(it -> it.getCode().equals(source))
+				.findFirst()
+				.orElse(null);
+		}
+	}
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProduct.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProduct.java
@@ -1,0 +1,23 @@
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Table("plain_products")
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class PlainProduct {
+
+	@Id
+	private final Long id;
+	private final String productName;
+	private final Instant createdAt;
+	private final Instant lastModifiedAt;
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProductWithSoftDeleteReview.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProductWithSoftDeleteReview.java
@@ -1,0 +1,28 @@
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.MappedCollection;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Table("plain_products")
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class PlainProductWithSoftDeleteReview {
+
+	@Id
+	private final Long id;
+	private final String productName;
+	private final Instant createdAt;
+	private final Instant lastModifiedAt;
+
+	@MappedCollection(idColumn = "product_id")
+	private final Set<SoftDeleteReview> reviews;
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProductWithSoftDeleteReviewRepository.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProductWithSoftDeleteReviewRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import com.navercorp.spring.data.jdbc.plus.repository.JdbcRepository;
+
+/**
+ * @author Chanhyeong Cho
+ */
+public interface PlainProductWithSoftDeleteReviewRepository
+	extends JdbcRepository<PlainProductWithSoftDeleteReview, Long> {
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainReview.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainReview.java
@@ -1,0 +1,24 @@
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Table("plain_reviews")
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class PlainReview {
+
+	@Id
+	private final Long id;
+	private final Long productId;
+	private final String contents;
+	private final Instant createdAt;
+	private final Instant lastModifiedAt;
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProduct.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProduct.java
@@ -1,0 +1,33 @@
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.MappedCollection;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import com.navercorp.spring.jdbc.plus.commons.annotations.SoftDeleteColumn;
+
+@Table("soft_delete_products")
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class SoftDeleteProduct {
+
+	@Id
+	private final Long id;
+	private final String productName;
+	private final Instant createdAt;
+	private final Instant lastModifiedAt;
+
+	@MappedCollection(idColumn = "product_id")
+	private final Set<SoftDeleteReview> reviews;
+
+	@SoftDeleteColumn.Boolean(valueAsDeleted = "false")
+	private final boolean visible;
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProductRepository.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProductRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import com.navercorp.spring.data.jdbc.plus.repository.JdbcRepository;
+
+/**
+ * @author Chanhyeong Cho
+ */
+public interface SoftDeleteProductRepository extends JdbcRepository<SoftDeleteProduct, Long> {
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProductWithPlainReview.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProductWithPlainReview.java
@@ -1,0 +1,33 @@
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.MappedCollection;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import com.navercorp.spring.jdbc.plus.commons.annotations.SoftDeleteColumn;
+
+@Table("soft_delete_products")
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class SoftDeleteProductWithPlainReview {
+
+	@Id
+	private final Long id;
+	private final String productName;
+	private final Instant createdAt;
+	private final Instant lastModifiedAt;
+
+	@MappedCollection(idColumn = "product_id")
+	private final Set<PlainReview> reviews;
+
+	@SoftDeleteColumn.Boolean(valueAsDeleted = "false")
+	private final boolean visible;
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProductWithPlainReviewRepository.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProductWithPlainReviewRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import com.navercorp.spring.data.jdbc.plus.repository.JdbcRepository;
+
+/**
+ * @author Chanhyeong Cho
+ */
+public interface SoftDeleteProductWithPlainReviewRepository
+	extends JdbcRepository<SoftDeleteProductWithPlainReview, Long> {
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteReview.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteReview.java
@@ -1,0 +1,29 @@
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import com.navercorp.spring.jdbc.plus.commons.annotations.SoftDeleteColumn;
+
+@Table("soft_delete_reviews")
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class SoftDeleteReview {
+
+	@Id
+	private final Long id;
+	private final Long productId;
+	private final String contents;
+	private final Instant createdAt;
+	private final Instant lastModifiedAt;
+
+	@SoftDeleteColumn.Boolean(valueAsDeleted = "false")
+	private final boolean visible;
+}

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteReviewRepository.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteReviewRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import java.util.List;
+
+import com.navercorp.spring.data.jdbc.plus.repository.JdbcRepository;
+
+/**
+ * @author Chanhyeong Cho
+ */
+public interface SoftDeleteReviewRepository extends JdbcRepository<SoftDeleteReview, Long> {
+
+	List<SoftDeleteReview> findAllByProductIdIn(List<Long> productIds);
+}

--- a/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/BooleanStateArticleRepositoryTest.java
+++ b/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/BooleanStateArticleRepositoryTest.java
@@ -72,9 +72,9 @@ public class BooleanStateArticleRepositoryTest {
 		Iterable<BooleanStateArticle> actual = this.sut.insertAll(articles);
 
 		// then
-		actual.forEach(order -> {
-			then(order.getId()).isNotNull();
-			then(order.isVisible()).isTrue();
+		actual.forEach(article -> {
+			then(article.getId()).isNotNull();
+			then(article.isVisible()).isTrue();
 		});
 	}
 

--- a/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/BooleanStateArticleRepositoryTest.java
+++ b/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/BooleanStateArticleRepositoryTest.java
@@ -1,0 +1,146 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.repository.guide.article;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Chanhyeong Cho
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class BooleanStateArticleRepositoryTest {
+	@Autowired
+	private BooleanStateArticleRepository sut;
+
+	private final List<BooleanStateArticle> articles = Arrays.asList(
+		BooleanStateArticle.builder()
+			.writerId("userId1")
+			.contents("First, Hello, World!")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.visible(true)
+			.build(),
+		BooleanStateArticle.builder()
+			.writerId("userId2")
+			.contents("Second, Hello, World!")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.visible(true)
+			.build(),
+		BooleanStateArticle.builder()
+			.writerId("userId3")
+			.contents("Third, Hello, World!")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.visible(true)
+			.build()
+	);
+
+	@Test
+	void insertAll() {
+		// when
+		Iterable<BooleanStateArticle> actual = this.sut.insertAll(articles);
+
+		// then
+		actual.forEach(order -> {
+			then(order.getId()).isNotNull();
+			then(order.isVisible()).isTrue();
+		});
+	}
+
+	@Test
+	void update() {
+		// given
+		BooleanStateArticle article = this.sut.insert(articles.get(0));
+		BooleanStateArticle changed = article.toBuilder()
+			.contents(article.getContents() + " Changed content")
+			.lastModifiedAt(Instant.now())
+			.build();
+
+		// when
+		BooleanStateArticle actual = this.sut.update(changed);
+
+		// then
+		then(actual.getContents())
+			.isEqualTo("First, Hello, World! Changed content");
+	}
+
+	@Test
+	void deleteById() {
+		// given
+		BooleanStateArticle article = this.sut.insert(articles.get(0));
+
+		// when
+		this.sut.deleteById(article.getId());
+
+		// then
+		Optional<BooleanStateArticle> markAsDeleted = this.sut.findById(article.getId());
+		then(markAsDeleted).isNotEmpty()
+			.hasValueSatisfying(it -> then(it.isVisible()).isFalse());
+	}
+
+	@Test
+	void deleteAllByEntities() {
+		// given
+		Iterable<BooleanStateArticle> insertedList = this.sut.insertAll(articles);
+		List<Long> ids = StreamSupport.stream(insertedList.spliterator(), false)
+			.map(BooleanStateArticle::getId)
+			.toList();
+
+		// when
+		this.sut.deleteAll(insertedList);
+
+		// then
+		Iterable<BooleanStateArticle> markAsDeletedList = this.sut.findAllById(ids);
+		then(markAsDeletedList).hasSize(ids.size())
+			.allSatisfy(it ->
+				then(it.isVisible()).isFalse()
+			);
+	}
+
+	@Test
+	void deleteAll() {
+		// given
+		this.sut.insertAll(articles);
+
+		// when
+		this.sut.deleteAll();
+
+		// then
+		Iterable<BooleanStateArticle> markAsDeletedList = this.sut.findAll();
+		then(markAsDeletedList).hasSize(articles.size())
+			.allSatisfy(it ->
+				then(it.isVisible()).isFalse()
+			);
+	}
+}

--- a/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/EnumStateArticleRepositoryTest.java
+++ b/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/EnumStateArticleRepositoryTest.java
@@ -1,0 +1,177 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.repository.guide.article;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.navercorp.spring.data.jdbc.plus.repository.guide.article.EnumStateArticle.State;
+
+/**
+ * @author Chanhyeong Cho
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class EnumStateArticleRepositoryTest {
+	@Autowired
+	private EnumStateArticleRepository sut;
+
+	private final List<EnumStateArticle> articles = Arrays.asList(
+		EnumStateArticle.builder()
+			.writerId("userId1")
+			.contents("First, Hello, World!")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.version(1)
+			.state(State.OPEN)
+			.build(),
+		EnumStateArticle.builder()
+			.writerId("userId2")
+			.contents("Second, Hello, World!")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.version(1)
+			.state(State.OPEN)
+			.build(),
+		EnumStateArticle.builder()
+			.writerId("userId3")
+			.contents("Third, Hello, World!")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.version(1)
+			.state(State.OPEN)
+			.build()
+	);
+
+	@Test
+	void insertAll() {
+		// when
+		Iterable<EnumStateArticle> actual = this.sut.insertAll(articles);
+
+		// then
+		actual.forEach(order -> {
+			then(order.getId()).isNotNull();
+			then(order.closed()).isFalse();
+		});
+	}
+
+	@Test
+	void update() {
+		// given
+		EnumStateArticle article = this.sut.insert(articles.get(0));
+		EnumStateArticle changed = article.toBuilder()
+			.contents(article.getContents() + " Changed content")
+			.lastModifiedAt(Instant.now())
+			.build();
+
+		// when
+		EnumStateArticle actual = this.sut.update(changed);
+
+		// then
+		then(actual.getContents())
+			.isEqualTo("First, Hello, World! Changed content");
+	}
+
+	@Test
+	void deleteByIdWithVersion() {
+		// given
+		EnumStateArticle article = this.sut.insert(articles.get(0));
+
+		// when
+		this.sut.delete(article);
+
+		// then
+		Optional<EnumStateArticle> markAsDeleted = this.sut.findById(article.getId());
+		then(markAsDeleted).isNotEmpty()
+			.hasValueSatisfying(it -> {
+					then(it.closed()).isTrue();
+					then(it.getVersion()).isGreaterThan(1); // version property updated
+				}
+			);
+	}
+
+	@Test
+	void deleteById() {
+		// given
+		EnumStateArticle article = this.sut.insert(articles.get(0));
+
+		// when
+		this.sut.deleteById(article.getId());
+
+		// then
+		Optional<EnumStateArticle> markAsDeleted = this.sut.findById(article.getId());
+		then(markAsDeleted).isNotEmpty()
+			.hasValueSatisfying(it -> {
+					then(it.closed()).isTrue();
+					then(it.getVersion()).isEqualTo(1); // increasing version not supported for delete by id
+				}
+			);
+	}
+
+	@Test
+	void deleteAllByEntities() {
+		// given
+		Iterable<EnumStateArticle> insertedList = this.sut.insertAll(articles);
+		List<Long> ids = StreamSupport.stream(insertedList.spliterator(), false)
+			.map(EnumStateArticle::getId)
+			.toList();
+
+		// when
+		this.sut.deleteAll(insertedList);
+
+		// then
+		Iterable<EnumStateArticle> markAsDeletedList = this.sut.findAllById(ids);
+		then(markAsDeletedList).hasSize(ids.size())
+			.allSatisfy(it -> {
+					then(it.closed()).isTrue();
+					then(it.getVersion()).isGreaterThan(1); // version property updated
+				}
+			);
+	}
+
+	@Test
+	void deleteAll() {
+		// given
+		this.sut.insertAll(articles);
+
+		// when
+		this.sut.deleteAll();
+
+		// then
+		Iterable<EnumStateArticle> markAsDeletedList = this.sut.findAll();
+		then(markAsDeletedList).hasSize(articles.size())
+			.allSatisfy(it -> {
+					then(it.closed()).isTrue();
+					then(it.getVersion()).isEqualTo(1); // increasing version not supported for delete all
+				}
+			);
+	}
+}

--- a/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/EnumStateArticleRepositoryTest.java
+++ b/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/article/EnumStateArticleRepositoryTest.java
@@ -77,9 +77,9 @@ public class EnumStateArticleRepositoryTest {
 		Iterable<EnumStateArticle> actual = this.sut.insertAll(articles);
 
 		// then
-		actual.forEach(order -> {
-			then(order.getId()).isNotNull();
-			then(order.closed()).isFalse();
+		actual.forEach(article -> {
+			then(article.getId()).isNotNull();
+			then(article.closed()).isFalse();
 		});
 	}
 

--- a/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProductWithSoftDeleteReviewRepositoryTest.java
+++ b/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProductWithSoftDeleteReviewRepositoryTest.java
@@ -1,0 +1,187 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Chanhyeong Cho
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class PlainProductWithSoftDeleteReviewRepositoryTest {
+
+	@Autowired
+	private SoftDeleteReviewRepository softDeleteReviewRepository;
+
+	@Autowired
+	private PlainProductWithSoftDeleteReviewRepository sut;
+
+	private final List<PlainProductWithSoftDeleteReview> products = Arrays.asList(
+		PlainProductWithSoftDeleteReview.builder()
+			.productName("product1")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.reviews(
+				Set.of(
+					SoftDeleteReview.builder()
+						.contents("product1 - review1")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.visible(true)
+						.build(),
+					SoftDeleteReview.builder()
+						.contents("product1 - review2")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.visible(true)
+						.build()
+				)
+			)
+			.build(),
+		PlainProductWithSoftDeleteReview.builder()
+			.productName("product2")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.reviews(
+				Set.of(
+					SoftDeleteReview.builder()
+						.contents("product2 - review1")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.visible(true)
+						.build()
+				)
+			)
+			.build(),
+		PlainProductWithSoftDeleteReview.builder()
+			.productName("product3")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.reviews(
+				Set.of(
+					SoftDeleteReview.builder()
+						.contents("product3 - review1")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.visible(true)
+						.build()
+				)
+			)
+			.build()
+	);
+
+	@Test
+	void insertAll() {
+		// when
+		Iterable<PlainProductWithSoftDeleteReview> actual = this.sut.insertAll(products);
+
+		// then
+		then(actual).hasSize(products.size());
+		actual.forEach(product -> {
+			then(product.getId()).isNotNull();
+			then(product.getReviews()).isNotEmpty()
+				.allSatisfy(
+					review -> {
+						then(review.getId()).isNotNull();
+						then(review.isVisible()).isTrue();
+					}
+				);
+		});
+	}
+
+	@Test
+	void deleteById() {
+		// given
+		PlainProductWithSoftDeleteReview product = this.sut.insert(products.get(0));
+
+		// when
+		this.sut.deleteById(product.getId());
+
+		// then
+		Optional<PlainProductWithSoftDeleteReview> productResult = this.sut.findById(product.getId());
+		then(productResult).isEmpty();
+
+		List<SoftDeleteReview> reviewResult =
+			this.softDeleteReviewRepository.findAllByProductIdIn(List.of(product.getId()));
+		then(reviewResult).isNotEmpty()
+			.allSatisfy(review ->
+				then(review.isVisible()).isFalse()
+			);
+	}
+
+	@Test
+	void deleteAllByEntities() {
+		// given
+		Iterable<PlainProductWithSoftDeleteReview> insertedList = this.sut.insertAll(products);
+		List<Long> ids = StreamSupport.stream(insertedList.spliterator(), false)
+			.map(PlainProductWithSoftDeleteReview::getId)
+			.toList();
+		int reviewsSize = StreamSupport.stream(insertedList.spliterator(), false)
+			.map(PlainProductWithSoftDeleteReview::getReviews)
+			.mapToInt(Set::size)
+			.sum();
+
+		// when
+		this.sut.deleteAll(insertedList);
+
+		// then
+		Iterable<PlainProductWithSoftDeleteReview> productResult = this.sut.findAllById(ids);
+		then(productResult).isEmpty();
+
+		Iterable<SoftDeleteReview> reviewResult = softDeleteReviewRepository.findAllByProductIdIn(ids);
+		then(reviewResult).hasSize(reviewsSize)
+			.allSatisfy(review ->
+				then(review.isVisible()).isFalse()
+			);
+	}
+
+	@Test
+	void deleteAll() {
+		// given
+		this.sut.insertAll(products);
+
+		// when
+		this.sut.deleteAll();
+
+		// then
+		Iterable<PlainProductWithSoftDeleteReview> productResult = this.sut.findAll();
+		then(productResult).isEmpty();
+
+		Iterable<SoftDeleteReview> reviewResult = softDeleteReviewRepository.findAll();
+		then(reviewResult).isNotEmpty()
+			.allSatisfy(review ->
+				then(review.isVisible()).isFalse()
+			);
+	}
+}

--- a/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProductRepositoryTest.java
+++ b/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProductRepositoryTest.java
@@ -1,0 +1,187 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Chanhyeong Cho
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class SoftDeleteProductRepositoryTest {
+	@Autowired
+	private SoftDeleteProductRepository sut;
+
+	private final List<SoftDeleteProduct> products = Arrays.asList(
+		SoftDeleteProduct.builder()
+			.productName("product1")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.visible(true)
+			.reviews(
+				Set.of(
+					SoftDeleteReview.builder()
+						.contents("product1 - review1")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.visible(true)
+						.build(),
+					SoftDeleteReview.builder()
+						.contents("product1 - review2")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.visible(true)
+						.build()
+				)
+			)
+			.build(),
+		SoftDeleteProduct.builder()
+			.productName("product2")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.visible(true)
+			.reviews(
+				Set.of(
+					SoftDeleteReview.builder()
+						.contents("product2 - review1")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.visible(true)
+						.build()
+				)
+			)
+			.build(),
+		SoftDeleteProduct.builder()
+			.productName("product3")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.visible(true)
+			.reviews(
+				Set.of(
+					SoftDeleteReview.builder()
+						.contents("product3 - review1")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.visible(true)
+						.build()
+				)
+			)
+			.build()
+	);
+
+	@Test
+	void insertAll() {
+		// when
+		Iterable<SoftDeleteProduct> actual = this.sut.insertAll(products);
+
+		// then
+		then(actual).hasSize(products.size());
+		actual.forEach(product -> {
+			then(product.getId()).isNotNull();
+			then(product.isVisible()).isTrue();
+			then(product.getReviews()).isNotEmpty()
+				.allSatisfy(
+					review -> {
+						then(review.getId()).isNotNull();
+						then(review.isVisible()).isTrue();
+					}
+				);
+		});
+	}
+
+	@Test
+	void deleteById() {
+		// given
+		SoftDeleteProduct product = this.sut.insert(products.get(0));
+
+		// when
+		this.sut.deleteById(product.getId());
+
+		// then
+		Optional<SoftDeleteProduct> markAsDeleted = this.sut.findById(product.getId());
+		then(markAsDeleted).isNotEmpty()
+			.hasValueSatisfying(p -> {
+				then(p.isVisible()).isFalse();
+				then(p.getReviews()).isNotEmpty()
+					.allSatisfy(review ->
+						then(review.isVisible()).isFalse()
+					);
+			});
+	}
+
+	@Test
+	void deleteAllByEntities() {
+		// given
+		Iterable<SoftDeleteProduct> insertedList = this.sut.insertAll(products);
+		List<Long> ids = StreamSupport.stream(insertedList.spliterator(), false)
+			.map(SoftDeleteProduct::getId)
+			.toList();
+
+		// when
+		this.sut.deleteAll(insertedList);
+
+		// then
+		Iterable<SoftDeleteProduct> markAsDeletedList = this.sut.findAllById(ids);
+		then(markAsDeletedList).hasSize(ids.size())
+			.allSatisfy(product -> {
+					then(product.isVisible()).isFalse();
+					then(product.getReviews()).isNotEmpty()
+						.allSatisfy(review ->
+							then(review.isVisible()).isFalse()
+						);
+				}
+			);
+	}
+
+	@Test
+	void deleteAll() {
+		// given
+		this.sut.insertAll(products);
+
+		// when
+		this.sut.deleteAll();
+
+		// then
+		Iterable<SoftDeleteProduct> markAsDeletedList = this.sut.findAll();
+		then(markAsDeletedList).hasSize(products.size())
+			.allSatisfy(product -> {
+					then(product.isVisible()).isFalse();
+					then(product.getReviews()).isNotEmpty()
+						.allSatisfy(review ->
+							then(review.isVisible()).isFalse()
+						);
+				}
+			);
+	}
+}

--- a/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProductWithPlainReviewRepositoryTest.java
+++ b/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/SoftDeleteProductWithPlainReviewRepositoryTest.java
@@ -1,0 +1,173 @@
+/*
+ * Spring JDBC Plus
+ *
+ * Copyright 2020-2024 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Chanhyeong Cho
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class SoftDeleteProductWithPlainReviewRepositoryTest {
+	@Autowired
+	private SoftDeleteProductWithPlainReviewRepository sut;
+
+	private final List<SoftDeleteProductWithPlainReview> products = Arrays.asList(
+		SoftDeleteProductWithPlainReview.builder()
+			.productName("product1")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.visible(true)
+			.reviews(
+				Set.of(
+					PlainReview.builder()
+						.contents("product1 - review1")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.build(),
+					PlainReview.builder()
+						.contents("product1 - review2")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.build()
+				)
+			)
+			.build(),
+		SoftDeleteProductWithPlainReview.builder()
+			.productName("product2")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.visible(true)
+			.reviews(
+				Set.of(
+					PlainReview.builder()
+						.contents("product2 - review1")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.build()
+				)
+			)
+			.build(),
+		SoftDeleteProductWithPlainReview.builder()
+			.productName("product3")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.visible(true)
+			.reviews(
+				Set.of(
+					PlainReview.builder()
+						.contents("product3 - review1")
+						.createdAt(Instant.now())
+						.lastModifiedAt(Instant.now())
+						.build()
+				)
+			)
+			.build()
+	);
+
+	@Test
+	void insertAll() {
+		// when
+		Iterable<SoftDeleteProductWithPlainReview> actual = this.sut.insertAll(products);
+
+		// then
+		then(actual).hasSize(products.size());
+		actual.forEach(product -> {
+			then(product.getId()).isNotNull();
+			then(product.isVisible()).isTrue();
+			then(product.getReviews()).isNotEmpty()
+				.allSatisfy(
+					review -> {
+						then(review.getId()).isNotNull();
+					}
+				);
+		});
+	}
+
+	@Test
+	void deleteById() {
+		// given
+		SoftDeleteProductWithPlainReview product = this.sut.insert(products.get(0));
+
+		// when
+		this.sut.deleteById(product.getId());
+
+		// then
+		Optional<SoftDeleteProductWithPlainReview> markAsDeleted = this.sut.findById(product.getId());
+		then(markAsDeleted).isNotEmpty()
+			.hasValueSatisfying(p -> {
+				then(p.isVisible()).isFalse();
+				then(p.getReviews()).isEmpty();
+			});
+	}
+
+	@Test
+	void deleteAllByEntities() {
+		// given
+		Iterable<SoftDeleteProductWithPlainReview> insertedList = this.sut.insertAll(products);
+		List<Long> ids = StreamSupport.stream(insertedList.spliterator(), false)
+			.map(SoftDeleteProductWithPlainReview::getId)
+			.toList();
+
+		// when
+		this.sut.deleteAll(insertedList);
+
+		// then
+		Iterable<SoftDeleteProductWithPlainReview> markAsDeletedList = this.sut.findAllById(ids);
+		then(markAsDeletedList).hasSize(ids.size())
+			.allSatisfy(product -> {
+					then(product.isVisible()).isFalse();
+					then(product.getReviews()).isEmpty();
+				}
+			);
+	}
+
+	@Test
+	void deleteAll() {
+		// given
+		this.sut.insertAll(products);
+
+		// when
+		this.sut.deleteAll();
+
+		// then
+		Iterable<SoftDeleteProductWithPlainReview> markAsDeletedList = this.sut.findAll();
+		then(markAsDeletedList).hasSize(products.size())
+			.allSatisfy(product -> {
+					then(product.isVisible()).isFalse();
+					then(product.getReviews()).isEmpty();
+				}
+			);
+	}
+}

--- a/guide-projects/plus-repository-guide/src/test/resources/data/schema.sql
+++ b/guide-projects/plus-repository-guide/src/test/resources/data/schema.sql
@@ -47,3 +47,36 @@ CREATE TABLE IF NOT EXISTS enum_state_articles (
     version INT,
     article_state VARCHAR(2),
     PRIMARY KEY(id));
+
+CREATE TABLE IF NOT EXISTS soft_delete_products (
+    id BIGINT AUTO_INCREMENT,
+    product_name VARCHAR(20),
+    created_at DATETIME,
+    last_modified_at DATETIME,
+    visible TINYINT,
+    PRIMARY KEY(id));
+
+CREATE TABLE IF NOT EXISTS soft_delete_reviews (
+    id BIGINT AUTO_INCREMENT,
+    product_id BIGINT,
+    contents TEXT,
+    created_at DATETIME,
+    last_modified_at DATETIME,
+    visible TINYINT,
+    PRIMARY KEY(id));
+
+CREATE TABLE IF NOT EXISTS plain_products (
+    id BIGINT AUTO_INCREMENT,
+    product_name VARCHAR(20),
+    created_at DATETIME,
+    last_modified_at DATETIME,
+    PRIMARY KEY(id));
+
+CREATE TABLE IF NOT EXISTS plain_reviews (
+    id BIGINT AUTO_INCREMENT,
+    product_id BIGINT,
+    contents TEXT,
+    created_at DATETIME,
+    last_modified_at DATETIME,
+    visible TINYINT,
+    PRIMARY KEY(id));

--- a/guide-projects/plus-repository-guide/src/test/resources/data/schema.sql
+++ b/guide-projects/plus-repository-guide/src/test/resources/data/schema.sql
@@ -28,3 +28,22 @@ CREATE TABLE IF NOT EXISTS n_shipping (
   receiver_address VARCHAR(255),
   memo VARCHAR(255),
   PRIMARY KEY(id));
+
+CREATE TABLE IF NOT EXISTS boolean_state_articles (
+    id BIGINT AUTO_INCREMENT,
+    writer_id VARCHAR(20),
+    contents TEXT,
+    created_at DATETIME,
+    last_modified_at DATETIME,
+    visible TINYINT,
+    PRIMARY KEY(id));
+
+CREATE TABLE IF NOT EXISTS enum_state_articles (
+    id BIGINT AUTO_INCREMENT,
+    writer_id VARCHAR(20),
+    contents TEXT,
+    created_at DATETIME,
+    last_modified_at DATETIME,
+    version INT,
+    article_state VARCHAR(2),
+    PRIMARY KEY(id));

--- a/spring-boot-autoconfigure-data-jdbc-plus/src/main/java/com/navercorp/spring/boot/autoconfigure/data/jdbc/plus/repository/JdbcPlusRepositoriesAutoConfiguration.java
+++ b/spring-boot-autoconfigure-data-jdbc-plus/src/main/java/com/navercorp/spring/boot/autoconfigure/data/jdbc/plus/repository/JdbcPlusRepositoriesAutoConfiguration.java
@@ -39,7 +39,6 @@ import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.core.convert.JdbcCustomConversions;
 import org.springframework.data.jdbc.core.convert.RelationResolver;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
-import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration;
 import org.springframework.data.relational.RelationalManagedTypes;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
@@ -47,6 +46,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import com.navercorp.spring.data.jdbc.plus.repository.JdbcRepository;
+import com.navercorp.spring.data.jdbc.plus.repository.config.AbstractJdbcPlusConfiguration;
 import com.navercorp.spring.data.jdbc.plus.repository.config.JdbcPlusRepositoryConfigExtension;
 import com.navercorp.spring.data.jdbc.plus.repository.config.JdbcPlusRepositoryReactiveSupportConfigExtension;
 
@@ -57,7 +57,7 @@ import com.navercorp.spring.data.jdbc.plus.repository.config.JdbcPlusRepositoryR
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnBean({NamedParameterJdbcOperations.class, PlatformTransactionManager.class})
-@ConditionalOnClass({NamedParameterJdbcOperations.class, AbstractJdbcConfiguration.class, JdbcRepository.class})
+@ConditionalOnClass({NamedParameterJdbcOperations.class, AbstractJdbcPlusConfiguration.class, JdbcRepository.class})
 @ConditionalOnExpression(
 	"!${spring.data.jdbc.repositories.enabled:true} " + " && ${spring.data.jdbc.plus.repositories.enabled:true}"
 )
@@ -97,8 +97,8 @@ public class JdbcPlusRepositoriesAutoConfiguration {
 	 * The type Spring boot jdbc configuration.
 	 */
 	@Configuration
-	@ConditionalOnMissingBean(AbstractJdbcConfiguration.class)
-	static class SpringBootJdbcConfiguration extends AbstractJdbcConfiguration {
+	@ConditionalOnMissingBean(AbstractJdbcPlusConfiguration.class)
+	static class SpringBootJdbcConfiguration extends AbstractJdbcPlusConfiguration {
 		@Override
 		@Bean
 		@ConditionalOnMissingBean

--- a/spring-data-jdbc-plus-repository/build.gradle
+++ b/spring-data-jdbc-plus-repository/build.gradle
@@ -1,6 +1,9 @@
 compileJava.dependsOn(processResources)
 
 dependencies {
+    api(project(":spring-jdbc-plus-commons"))
+    api(project(":spring-data-jdbc-plus-support"))
+
     api("org.springframework.data:spring-data-jdbc")
     api("org.springframework.data:spring-data-relational")
     api("org.springframework.data:spring-data-commons")

--- a/spring-data-jdbc-plus-repository/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/config/AbstractJdbcPlusConfiguration.java
+++ b/spring-data-jdbc-plus-repository/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/config/AbstractJdbcPlusConfiguration.java
@@ -1,0 +1,38 @@
+package com.navercorp.spring.data.jdbc.plus.repository.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.JdbcConverter;
+import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
+import org.springframework.data.jdbc.repository.config.AbstractJdbcConfiguration;
+import org.springframework.data.relational.core.dialect.Dialect;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+
+import com.navercorp.spring.data.jdbc.plus.support.convert.JdbcPlusDataAccessStrategyFactory;
+import com.navercorp.spring.data.jdbc.plus.support.convert.SqlGeneratorSource;
+import com.navercorp.spring.data.jdbc.plus.support.parametersource.SoftDeleteSqlParametersFactory;
+
+public class AbstractJdbcPlusConfiguration extends AbstractJdbcConfiguration {
+
+	@Override
+	@Bean
+	public DataAccessStrategy dataAccessStrategyBean(
+		NamedParameterJdbcOperations operations,
+		JdbcConverter jdbcConverter,
+		JdbcMappingContext context,
+		Dialect dialect
+	) {
+		DataAccessStrategy delegate = super.dataAccessStrategyBean(operations, jdbcConverter, context, dialect);
+
+		SqlGeneratorSource sqlGeneratorSource = new SqlGeneratorSource(context, jdbcConverter, dialect);
+		JdbcPlusDataAccessStrategyFactory factory = new JdbcPlusDataAccessStrategyFactory(
+			delegate,
+			jdbcConverter,
+			operations,
+			sqlGeneratorSource,
+			new SoftDeleteSqlParametersFactory(context, jdbcConverter)
+		);
+
+		return factory.create();
+	}
+}

--- a/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/convert/DefaultSoftDeleteProperty.java
+++ b/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/convert/DefaultSoftDeleteProperty.java
@@ -1,0 +1,119 @@
+package com.navercorp.spring.data.jdbc.plus.support.convert;
+
+import java.util.Arrays;
+
+import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+
+import com.navercorp.spring.jdbc.plus.commons.annotations.SoftDeleteColumn;
+
+class DefaultSoftDeleteProperty implements SoftDeleteProperty {
+
+	private static final SoftDeleteProperty NOT_EXISTS = new DefaultSoftDeleteProperty(false, SqlIdentifier.EMPTY, "");
+
+	private final boolean exists;
+	private final SqlIdentifier columnName;
+	private final Object updateValue;
+
+	private DefaultSoftDeleteProperty(boolean exists, SqlIdentifier columnName, @Nullable Object updateValue) {
+		this.exists = exists;
+		this.columnName = columnName;
+		this.updateValue = updateValue;
+	}
+
+	static SoftDeleteProperty from(RelationalPersistentEntity<?> entity) {
+		RelationalPersistentProperty softDeleteProperty = findSoftDeleteProperty(entity);
+		if (softDeleteProperty == null) {
+			return NOT_EXISTS;
+		}
+
+		return new DefaultSoftDeleteProperty(
+			true,
+			softDeleteProperty.getColumnName(),
+			getSoftDeleteColumnUpdateValue(softDeleteProperty)
+		);
+	}
+
+	@Nullable
+	private static RelationalPersistentProperty findSoftDeleteProperty(RelationalPersistentEntity<?> entity) {
+		for (RelationalPersistentProperty property : entity) {
+			if (property.isAnnotationPresent(SoftDeleteColumn.class)) {
+				return property;
+			}
+		}
+
+		return null;
+	}
+
+	private static Object getSoftDeleteColumnUpdateValue(RelationalPersistentProperty property) {
+		SoftDeleteColumn annotation = property.getRequiredAnnotation(SoftDeleteColumn.class);
+		if (!StringUtils.hasText(annotation.valueAsDeleted())) {
+			throw new IllegalArgumentException("SoftDeleteColum.valueAsDeleted() is Empty.");
+		}
+
+		return switch (annotation.type()) {
+			case BOOLEAN -> getBooleanUpdateValue(annotation.valueAsDeleted());
+			case STRING -> getStringUpdateValue(property, annotation.valueAsDeleted());
+		};
+	}
+
+	private static boolean getBooleanUpdateValue(String value) {
+		if ("true".equals(value) || "false".equals(value)) {
+			return java.lang.Boolean.parseBoolean(value);
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid value %s provided for Boolean type of SoftDeleteColumn".formatted(value)
+		);
+	}
+
+	private static Object getStringUpdateValue(
+		RelationalPersistentProperty property,
+		String value
+	) {
+		Class<?> actualType = property.getActualType();
+
+		// if actual type is not enum, just return string value.
+		if (!actualType.isEnum()) {
+			return value;
+		}
+
+		// if actual type is enum type, cast to actual enum value to use type converter.
+		return Arrays.stream((Enum<?>[])actualType.getEnumConstants())
+			.filter(enumValue -> enumValue.name().equals(value))
+			.findFirst()
+			.orElseThrow(() ->
+				new IllegalArgumentException(
+					"Invalid enum name is provided. type: %s, name: %s".formatted(
+						actualType.getSimpleName(),
+						value
+					)
+				)
+			);
+	}
+
+	public boolean exists() {
+		return exists;
+	}
+
+	public SqlIdentifier getColumnName() {
+		requireExists();
+
+		return columnName;
+	}
+
+	public Object getUpdateValue() {
+		requireExists();
+
+		return updateValue;
+	}
+
+	private void requireExists() {
+		if (!exists) {
+			throw new IllegalStateException("SoftDeleteProperty should exist to use columnName/updateValue.");
+		}
+	}
+}

--- a/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/convert/JdbcPlusDataAccessStrategy.java
+++ b/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/convert/JdbcPlusDataAccessStrategy.java
@@ -1,0 +1,216 @@
+package com.navercorp.spring.data.jdbc.plus.support.convert;
+
+import static com.navercorp.spring.data.jdbc.plus.support.convert.SqlGenerator.IDS_SQL_PARAMETER;
+import static com.navercorp.spring.data.jdbc.plus.support.convert.SqlGenerator.ID_SQL_PARAMETER;
+import static com.navercorp.spring.data.jdbc.plus.support.convert.SqlGenerator.VERSION_SQL_PARAMETER;
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.DelegatingDataAccessStrategy;
+import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
+import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.util.Assert;
+
+import com.navercorp.spring.data.jdbc.plus.support.parametersource.SoftDeleteSqlParametersFactory;
+
+public class JdbcPlusDataAccessStrategy extends DelegatingDataAccessStrategy {
+
+	private final RelationalMappingContext context;
+	private final NamedParameterJdbcOperations operations;
+	private final SqlGeneratorSource sqlGeneratorSource;
+	private final SoftDeleteSqlParametersFactory softDeleteSqlParametersFactory;
+
+	public JdbcPlusDataAccessStrategy(
+		DataAccessStrategy delegate,
+		RelationalMappingContext context,
+		NamedParameterJdbcOperations operations,
+		SqlGeneratorSource sqlGeneratorSource,
+		SoftDeleteSqlParametersFactory softDeleteSqlParametersFactory
+	) {
+		super(delegate);
+
+		Assert.notNull(context, "RelationalMappingContext must not be null");
+		Assert.notNull(operations, "NamedParameterJdbcOperations must not be null");
+		Assert.notNull(sqlGeneratorSource, "SqlGeneratorSource must not be null");
+		Assert.notNull(softDeleteSqlParametersFactory, "SoftDeleteSqlParameterFactory must not be null");
+
+		this.context = context;
+		this.operations = operations;
+		this.sqlGeneratorSource = sqlGeneratorSource;
+		this.softDeleteSqlParametersFactory = softDeleteSqlParametersFactory;
+	}
+
+	@Override
+	public void delete(Object rootId, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+		RelationalPersistentEntity<?> rootEntity = context.getRequiredPersistentEntity(getBaseType(propertyPath));
+
+		RelationalPersistentProperty referencingProperty = propertyPath.getLeafProperty();
+		Assert.notNull(referencingProperty, "No property found matching the PropertyPath " + propertyPath);
+
+		if (!supportsSoftDelete(rootEntity.getType())) {
+			super.delete(rootId, propertyPath);
+			return;
+		}
+
+		String softDelete = sql(rootEntity.getType()).getSoftDeleteById();
+
+		SqlParameterSource parameters = softDeleteSqlParametersFactory.forSoftDeleteById(
+			rootId,
+			rootEntity.getType(),
+			ID_SQL_PARAMETER,
+			requireNonNull(getSoftDeleteProperty(rootEntity.getType()))
+		);
+		operations.update(softDelete, parameters);
+	}
+
+	@Override
+	public void delete(Iterable<Object> rootIds, PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+		RelationalPersistentEntity<?> rootEntity = context.getRequiredPersistentEntity(getBaseType(propertyPath));
+
+		RelationalPersistentProperty referencingProperty = propertyPath.getLeafProperty();
+		Assert.notNull(referencingProperty, "No property found matching the PropertyPath " + propertyPath);
+
+		if (!supportsSoftDelete(rootEntity.getType())) {
+			super.delete(rootIds, propertyPath);
+			return;
+		}
+
+		String softDelete = sql(rootEntity.getType()).getDeleteByIdIn();
+
+		SqlParameterSource parameters = softDeleteSqlParametersFactory.forSoftDeleteByIds(
+			rootIds,
+			rootEntity.getType(),
+			IDS_SQL_PARAMETER,
+			requireNonNull(getSoftDeleteProperty(rootEntity.getType()))
+		);
+		operations.update(softDelete, parameters);
+	}
+
+	@Override
+	public void delete(Object id, Class<?> domainType) {
+		if (!supportsSoftDelete(domainType)) {
+			super.delete(id, domainType);
+			return;
+		}
+
+		String deleteByIdSql = sql(domainType).getSoftDeleteById();
+		SqlParameterSource parameter = softDeleteSqlParametersFactory.forSoftDeleteById(
+			id,
+			domainType,
+			ID_SQL_PARAMETER,
+			requireNonNull(getSoftDeleteProperty(domainType))
+		);
+
+		operations.update(deleteByIdSql, parameter);
+	}
+
+	@Override
+	public void delete(Iterable<Object> ids, Class<?> domainType) {
+		if (!supportsSoftDelete(domainType)) {
+			super.delete(ids, domainType);
+			return;
+		}
+
+		String softDelete = sql(domainType).getSoftDeleteByIdIn();
+		SqlParameterSource parameter = softDeleteSqlParametersFactory.forSoftDeleteByIds(
+			ids,
+			domainType,
+			IDS_SQL_PARAMETER,
+			requireNonNull(getSoftDeleteProperty(domainType))
+		);
+
+		operations.update(softDelete, parameter);
+	}
+
+	@Override
+	public <T> void deleteWithVersion(Object id, Class<T> domainType, Number previousVersion) {
+		if (!supportsSoftDelete(domainType)) {
+			super.deleteWithVersion(id, domainType, previousVersion);
+			return;
+		}
+
+		SqlParameterSource parameterSource = softDeleteSqlParametersFactory.forSoftDeleteByIdWithVersion(
+			id,
+			domainType,
+			ID_SQL_PARAMETER,
+			requireNonNull(getSoftDeleteProperty(domainType)),
+			VERSION_SQL_PARAMETER,
+			previousVersion
+		);
+
+		int affectedRows = operations.update(sql(domainType).getSoftDeleteByIdAndVersion(), parameterSource);
+
+		if (affectedRows == 0) {
+			throw new OptimisticLockingFailureException(
+				String.format("Optimistic lock exception deleting entity of type %s", domainType.getName()));
+		}
+	}
+
+	@Override
+	public <T> void deleteAll(Class<T> domainType) {
+		if (!supportsSoftDelete(domainType)) {
+			super.deleteAll(domainType);
+			return;
+		}
+
+		SqlParameterSource parameterSource = softDeleteSqlParametersFactory.forSoftDeleteAll(
+			requireNonNull(getSoftDeleteProperty(domainType))
+		);
+
+		operations.update(
+			sql(domainType).createSoftDeleteAllSql(null),
+			parameterSource
+		);
+	}
+
+	@Override
+	public void deleteAll(PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+		Class<?> domainType = getBaseType(propertyPath);
+
+		if (!supportsSoftDelete(domainType)) {
+			super.deleteAll(domainType);
+			return;
+		}
+
+		SqlParameterSource parameterSource = softDeleteSqlParametersFactory.forSoftDeleteAll(
+			requireNonNull(getSoftDeleteProperty(domainType))
+		);
+
+		operations.update(
+			sql(domainType).createSoftDeleteAllSql(propertyPath),
+			parameterSource
+		);
+	}
+
+	private boolean supportsSoftDelete(Class<?> domainType) {
+		return getSoftDeleteProperty(domainType).exists();
+	}
+
+	private SoftDeleteProperty getSoftDeleteProperty(Class<?> domainType) {
+		return sql(domainType).getSoftDeleteProperty();
+	}
+
+	/**
+	 * COPY {@link org.springframework.data.jdbc.core.convert.DefaultDataAccessStrategy#sql}
+	 */
+	private SqlGenerator sql(Class<?> domainType) {
+		return sqlGeneratorSource.getSqlGenerator(domainType);
+	}
+
+	/**
+	 * COPY {@link org.springframework.data.jdbc.core.convert.DefaultDataAccessStrategy#getBaseType}
+	 */
+	private Class<?> getBaseType(PersistentPropertyPath<RelationalPersistentProperty> propertyPath) {
+
+		RelationalPersistentProperty baseProperty = propertyPath.getBaseProperty();
+
+		Assert.notNull(baseProperty, "The base property must not be null");
+
+		return baseProperty.getOwner().getType();
+	}
+}

--- a/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/convert/JdbcPlusDataAccessStrategyFactory.java
+++ b/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/convert/JdbcPlusDataAccessStrategyFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.navercorp.spring.data.jdbc.plus.support.convert;
+
+import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.DefaultDataAccessStrategy;
+import org.springframework.data.jdbc.core.convert.JdbcConverter;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.util.Assert;
+
+import com.navercorp.spring.data.jdbc.plus.support.parametersource.SoftDeleteSqlParametersFactory;
+
+/**
+ * Factory to create a {@link DataAccessStrategy} based on the configuration of the provided components. Specifically,
+ * this factory creates a {@link SingleQueryFallbackDataAccessStrategy} that falls back to
+ * {@link DefaultDataAccessStrategy} if Single Query Loading is not supported. This factory encapsulates
+ * {@link DataAccessStrategy} for consistent access strategy creation.
+ *
+ * @since 3.3
+ */
+public class JdbcPlusDataAccessStrategyFactory {
+
+	private final DataAccessStrategy delegate;
+	private final JdbcConverter converter;
+	private final NamedParameterJdbcOperations operations;
+	private final SqlGeneratorSource jdbcPlusSqlGeneratorSource;
+	private final SoftDeleteSqlParametersFactory softDeleteSqlParametersFactory;
+
+	public JdbcPlusDataAccessStrategyFactory(
+		DataAccessStrategy delegate,
+		JdbcConverter converter,
+		NamedParameterJdbcOperations operations,
+		SqlGeneratorSource sqlGeneratorSource,
+		SoftDeleteSqlParametersFactory softDeleteSqlParametersFactory
+	) {
+		Assert.notNull(delegate, "DataAccessStrategy must not be null");
+		Assert.notNull(converter, "JdbcConverter must not be null");
+		Assert.notNull(operations, "NamedParameterJdbcOperations must not be null");
+		Assert.notNull(sqlGeneratorSource, "SqlGeneratorSource must not be null");
+		Assert.notNull(softDeleteSqlParametersFactory, "SoftDeleteSqlParametersFactory must not be null");
+
+		this.delegate = delegate;
+		this.converter = converter;
+		this.operations = operations;
+		this.jdbcPlusSqlGeneratorSource = sqlGeneratorSource;
+		this.softDeleteSqlParametersFactory = softDeleteSqlParametersFactory;
+	}
+
+	public DataAccessStrategy create() {
+		return new JdbcPlusDataAccessStrategy(
+			delegate,
+			this.converter.getMappingContext(),
+			this.operations,
+			jdbcPlusSqlGeneratorSource,
+			softDeleteSqlParametersFactory
+		);
+	}
+}

--- a/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/convert/SoftDeleteProperty.java
+++ b/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/convert/SoftDeleteProperty.java
@@ -1,126 +1,25 @@
 package com.navercorp.spring.data.jdbc.plus.support.convert;
 
-import java.util.Arrays;
-
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
-import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
-import org.springframework.lang.Nullable;
-import org.springframework.util.StringUtils;
 
-import com.navercorp.spring.jdbc.plus.commons.annotations.SoftDeleteColumn;
 
 /**
  * A property to generate sql for soft delete.
  *
  * @since 3.3
  */
-class SoftDeleteProperty {
-	private static final SoftDeleteProperty NOT_EXISTS = new SoftDeleteProperty(false, SqlIdentifier.EMPTY, "");
-
-	private final boolean exists;
-
-	private final SqlIdentifier columnName;
-
-	private final Object updateValue;
-
-	private SoftDeleteProperty(boolean exists, SqlIdentifier columnName, @Nullable Object updateValue) {
-		this.exists = exists;
-		this.columnName = columnName;
-		this.updateValue = updateValue;
-	}
+public interface SoftDeleteProperty {
 
 
 	static SoftDeleteProperty from(RelationalPersistentEntity<?> entity) {
-		RelationalPersistentProperty softDeleteProperty = findSoftDeleteProperty(entity);
-		if (softDeleteProperty == null) {
-			return NOT_EXISTS;
-		}
-
-		return new SoftDeleteProperty(
-			true,
-			softDeleteProperty.getColumnName(),
-			getSoftDeleteColumnUpdateValue(softDeleteProperty)
-		);
+		return DefaultSoftDeleteProperty.from(entity);
 	}
 
-	@Nullable
-	private static RelationalPersistentProperty findSoftDeleteProperty(RelationalPersistentEntity<?> entity) {
-		for (RelationalPersistentProperty property : entity) {
-			if (property.isAnnotationPresent(SoftDeleteColumn.class)) {
-				return property;
-			}
-		}
 
-		return null;
-	}
+	boolean exists();
 
-	private static Object getSoftDeleteColumnUpdateValue(RelationalPersistentProperty property) {
-		SoftDeleteColumn annotation = property.getRequiredAnnotation(SoftDeleteColumn.class);
-		if (!StringUtils.hasText(annotation.valueAsDeleted())) {
-			throw new IllegalArgumentException("SoftDeleteColum.valueAsDeleted() is Empty.");
-		}
+	SqlIdentifier getColumnName();
 
-		return switch (annotation.type()) {
-			case BOOLEAN -> getBooleanUpdateValue(annotation.valueAsDeleted());
-			case STRING -> getStringUpdateValue(property, annotation.valueAsDeleted());
-		};
-	}
-
-	private static boolean getBooleanUpdateValue(String value) {
-		if ("true".equals(value) || "false".equals(value)) {
-			return java.lang.Boolean.parseBoolean(value);
-		}
-
-		throw new IllegalArgumentException(
-			"Invalid value %s provided for Boolean type of SoftDeleteColumn".formatted(value)
-		);
-	}
-
-	private static Object getStringUpdateValue(
-		RelationalPersistentProperty property,
-		String value
-	) {
-		Class<?> actualType = property.getActualType();
-
-		// if actual type is not enum, just return string value.
-		if (!actualType.isEnum()) {
-			return value;
-		}
-
-		// if actual type is enum type, cast to actual enum value to use type converter.
-		return Arrays.stream((Enum<?>[])actualType.getEnumConstants())
-			.filter(enumValue -> enumValue.name().equals(value))
-			.findFirst()
-			.orElseThrow(() ->
-				new IllegalArgumentException(
-					"Invalid enum name is provided. type: %s, name: %s".formatted(
-						actualType.getSimpleName(),
-						value
-					)
-				)
-			);
-	}
-
-	public boolean exists() {
-		return exists;
-	}
-
-	public SqlIdentifier getColumnName() {
-		requireExists();
-
-		return columnName;
-	}
-
-	public Object getUpdateValue() {
-		requireExists();
-
-		return updateValue;
-	}
-
-	private void requireExists() {
-		if (!exists) {
-			throw new IllegalStateException("SoftDeleteProperty should exist to use columnName/updateValue.");
-		}
-	}
+	Object getUpdateValue();
 }

--- a/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/convert/SqlGenerator.java
+++ b/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/convert/SqlGenerator.java
@@ -1099,6 +1099,30 @@ class SqlGenerator {
 		return render(update);
 	}
 
+	/**
+	 * Create a {@code DELETE} query and filter by {@link PersistentPropertyPath} using {@code WHERE} with the {@code =}
+	 * operator.
+	 * @param path must not be {@literal null}.
+	 * @return the statement as a {@link String}. Guaranteed to be not {@literal null}.
+	 */
+	String createSoftDeleteByPath(PersistentPropertyPath<RelationalPersistentProperty> path) {
+		return createSoftDeleteByPathAndCriteria(mappingContext.getAggregatePath(path),
+			filterColumn -> filterColumn.isEqualTo(getBindMarker(ROOT_ID_PARAMETER)));
+	}
+
+	/**
+	 * Create a {@code DELETE} query and filter by {@link PersistentPropertyPath} using {@code WHERE} with the {@code IN}
+	 * operator.
+	 *
+	 * @param path must not be {@literal null}.
+	 * @return the statement as a {@link String}. Guaranteed to be not {@literal null}.
+	 */
+	String createSoftDeleteInByPath(PersistentPropertyPath<RelationalPersistentProperty> path) {
+
+		return createSoftDeleteByPathAndCriteria(mappingContext.getAggregatePath(path),
+			filterColumn -> filterColumn.in(getBindMarker(IDS_SQL_PARAMETER)));
+	}
+
 	String createSoftDeleteAllSql(@Nullable PersistentPropertyPath<RelationalPersistentProperty> path) {
 
 		Table table = getDmlTable();

--- a/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/parametersource/SoftDeleteSqlParametersFactory.java
+++ b/spring-data-jdbc-plus-support/src/main/java/com/navercorp/spring/data/jdbc/plus/support/parametersource/SoftDeleteSqlParametersFactory.java
@@ -1,0 +1,231 @@
+package com.navercorp.spring.data.jdbc.plus.support.parametersource;
+
+import java.sql.JDBCType;
+import java.sql.SQLType;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.jdbc.core.convert.JdbcConverter;
+import org.springframework.data.jdbc.core.mapping.JdbcValue;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
+import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.support.JdbcUtils;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+import com.navercorp.spring.data.jdbc.plus.support.convert.SoftDeleteProperty;
+
+public class SoftDeleteSqlParametersFactory {
+
+	private final RelationalMappingContext context;
+	private final JdbcConverter converter;
+
+	public SoftDeleteSqlParametersFactory(
+		RelationalMappingContext context,
+		JdbcConverter converter
+	) {
+		this.context = context;
+		this.converter = converter;
+	}
+
+	public <T> SqlParameterSource forSoftDeleteById(
+		Object id,
+		Class<T> domainType,
+		SqlIdentifier name,
+		SoftDeleteProperty softDeleteProperty
+	) {
+		SqlIdentifierParameterSource parameterSource = new SqlIdentifierParameterSource();
+
+		addConvertedPropertyValue(
+			parameterSource,
+			getRequiredPersistentEntity(domainType).getRequiredIdProperty(),
+			id,
+			name
+		);
+
+		addSoftDeletePropertyValue(softDeleteProperty, parameterSource);
+
+		return parameterSource;
+	}
+
+	public <T> SqlParameterSource forSoftDeleteByIdWithVersion(
+		Object id,
+		Class<T> domainType,
+		SqlIdentifier name,
+		SoftDeleteProperty softDeleteProperty,
+		SqlIdentifier versionPropertyName,
+		Number previousVersion
+	) {
+		SqlIdentifierParameterSource parameterSource = new SqlIdentifierParameterSource();
+
+		addConvertedPropertyValue(
+			parameterSource,
+			getRequiredPersistentEntity(domainType).getRequiredIdProperty(),
+			id,
+			name
+		);
+
+		parameterSource.addValue(versionPropertyName, previousVersion);
+		addVersionToUpdatePropertyValue(domainType, previousVersion, parameterSource);
+
+		addSoftDeletePropertyValue(softDeleteProperty, parameterSource);
+
+		return parameterSource;
+	}
+
+	public <T> SqlParameterSource forSoftDeleteAll(SoftDeleteProperty softDeleteProperty) {
+		SqlIdentifierParameterSource parameterSource = new SqlIdentifierParameterSource();
+
+		addSoftDeletePropertyValue(softDeleteProperty, parameterSource);
+
+		return parameterSource;
+	}
+
+	public <T> SqlParameterSource forSoftDeleteByIds(
+		Iterable<?> ids,
+		Class<T> domainType,
+		SqlIdentifier idsPropertyName,
+		SoftDeleteProperty softDeleteProperty
+	) {
+
+		SqlIdentifierParameterSource parameterSource = new SqlIdentifierParameterSource();
+
+		addConvertedPropertyValuesAsList(
+			parameterSource,
+			getRequiredPersistentEntity(domainType).getRequiredIdProperty(),
+			ids,
+			idsPropertyName
+		);
+
+		addSoftDeletePropertyValue(softDeleteProperty, parameterSource);
+
+		return parameterSource;
+	}
+
+	/**
+	 * COPY {@link org.springframework.data.jdbc.core.convert.SqlParametersFactory#getRequiredPersistentEntity}
+	 */
+	@SuppressWarnings("unchecked")
+	private <S> RelationalPersistentEntity<S> getRequiredPersistentEntity(Class<S> domainType) {
+		return (RelationalPersistentEntity<S>)context.getRequiredPersistentEntity(domainType);
+	}
+
+	/**
+	 * COPY {@link org.springframework.data.jdbc.core.convert.SqlParametersFactory#addConvertedPropertyValue}
+	 */
+	private void addConvertedPropertyValue(
+		SqlIdentifierParameterSource parameterSource,
+		RelationalPersistentProperty property,
+		@Nullable Object value,
+		SqlIdentifier name
+	) {
+
+		addConvertedValue(
+			parameterSource,
+			value,
+			name,
+			converter.getColumnType(property),
+			converter.getTargetSqlType(property)
+		);
+	}
+
+	/**
+	 * COPY {@link org.springframework.data.jdbc.core.convert.SqlParametersFactory#addConvertedPropertyValuesAsList}
+	 *
+	 * diff: additional 'idsPropertyName' parameter because of SqlGenerator's access modifier
+	 */
+	private void addConvertedPropertyValuesAsList(
+		SqlIdentifierParameterSource parameterSource,
+		RelationalPersistentProperty property,
+		Iterable<?> values,
+		SqlIdentifier idsPropertyName
+	) {
+
+		List<Object> convertedIds = new ArrayList<>();
+		JdbcValue jdbcValue = null;
+		for (Object id : values) {
+
+			Class<?> columnType = converter.getColumnType(property);
+			SQLType sqlType = converter.getTargetSqlType(property);
+
+			jdbcValue = converter.writeJdbcValue(id, columnType, sqlType);
+			convertedIds.add(jdbcValue.getValue());
+		}
+
+		Assert.state(jdbcValue != null, "JdbcValue must be not null at this point; Please report this as a bug");
+
+		SQLType jdbcType = jdbcValue.getJdbcType();
+		int typeNumber = jdbcType == null ? JdbcUtils.TYPE_UNKNOWN : jdbcType.getVendorTypeNumber();
+
+		parameterSource.addValue(idsPropertyName, convertedIds, typeNumber);
+	}
+
+	private void addConvertedValue(
+		SqlIdentifierParameterSource parameterSource,
+		@Nullable Object value,
+		SqlIdentifier paramName,
+		Class<?> javaType,
+		SQLType sqlType
+	) {
+
+		JdbcValue jdbcValue = converter.writeJdbcValue(
+			value,
+			javaType,
+			sqlType
+		);
+
+		parameterSource.addValue(
+			paramName,
+			jdbcValue.getValue(),
+			jdbcValue.getJdbcType().getVendorTypeNumber()
+		);
+	}
+
+	private <S> void addVersionToUpdatePropertyValue(
+		Class<S> domainType,
+		Number previousVersion,
+		SqlIdentifierParameterSource parameterSource
+	) {
+		RelationalPersistentEntity<S> persistentEntity = getRequiredPersistentEntity(domainType);
+
+		persistentEntity.doWithAll(property -> {
+			if (property.isVersionProperty()) {
+				SqlIdentifier paramName = property.getColumnName();
+
+				addConvertedPropertyValue(
+					parameterSource,
+					property,
+					previousVersion.longValue() + 1,
+					paramName
+				);
+			}
+		});
+	}
+
+	private void addSoftDeletePropertyValue(
+		SoftDeleteProperty softDeleteProperty,
+		SqlIdentifierParameterSource parameterSource
+	) {
+		Object updateValue = softDeleteProperty.getUpdateValue();
+
+		if (updateValue instanceof Boolean) {
+			boolean booleanValue = Boolean.TRUE.equals(updateValue);
+
+			parameterSource.addValue(
+				softDeleteProperty.getColumnName(),
+				booleanValue ? 1 : 0,
+				JDBCType.INTEGER.getVendorTypeNumber()
+			);
+		} else {
+			parameterSource.addValue(
+				softDeleteProperty.getColumnName(),
+				converter.writeValue(updateValue, TypeInformation.of(updateValue.getClass())),
+				JDBCType.VARCHAR.getVendorTypeNumber()
+			);
+		}
+	}
+}

--- a/spring-data-jdbc-plus-support/src/test/java/com/navercorp/spring/data/jdbc/plus/support/convert/PersistentPropertyPathTestUtils.java
+++ b/spring-data-jdbc-plus-support/src/test/java/com/navercorp/spring/data/jdbc/plus/support/convert/PersistentPropertyPathTestUtils.java
@@ -1,6 +1,7 @@
 package com.navercorp.spring.data.jdbc.plus.support.convert;
 
 import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.mapping.PersistentPropertyPaths;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 
@@ -14,13 +15,15 @@ public class PersistentPropertyPathTestUtils {
 	public static PersistentPropertyPath<RelationalPersistentProperty> getPath(
 		RelationalMappingContext context,
 		String path,
-		Class<?> baseType
+		Class<?> source
 	) {
-		return context.findPersistentPropertyPaths(baseType, p -> p.isEntity()) //
-			.filter(p -> p.toDotPath().equals(path)) //
-			.stream() //
-			.findFirst() //
-			.orElseThrow(() -> new IllegalArgumentException(
-				String.format("No path for %s based on %s", path, baseType)));
+		PersistentPropertyPaths<?, RelationalPersistentProperty> persistentPropertyPaths = context
+			.findPersistentPropertyPaths(source, p -> true);
+
+		return persistentPropertyPaths
+			.filter(p -> p.toDotPath().equals(path))
+			.stream()
+			.findFirst()
+			.orElse(null);
 	}
 }

--- a/spring-data-jdbc-plus-support/src/test/java/com/navercorp/spring/data/jdbc/plus/support/convert/SqlGeneratorTest.java
+++ b/spring-data-jdbc-plus-support/src/test/java/com/navercorp/spring/data/jdbc/plus/support/convert/SqlGeneratorTest.java
@@ -790,8 +790,11 @@ class SqlGeneratorTest {
 
 	@Test
 	void softDeleteByIdWithBoolean() {
-		assertThat(createSqlGenerator(BooleanValueSoftDeleteArticle.class, NonQuotingDialect.INSTANCE).getSoftDeleteById())
-			.isEqualTo("UPDATE boolean_value_article SET x_deleted = :x_deleted WHERE boolean_value_article.x_id = :id");
+		assertThat(
+			createSqlGenerator(BooleanValueSoftDeleteArticle.class, NonQuotingDialect.INSTANCE).getSoftDeleteById()
+		).isEqualTo(
+			"UPDATE boolean_value_article SET x_deleted = :x_deleted WHERE boolean_value_article.x_id = :id"
+		);
 	}
 
 	@Test
@@ -802,20 +805,29 @@ class SqlGeneratorTest {
 
 	@Test
 	void softDeleteByIdWithString() {
-		assertThat(createSqlGenerator(StringValueSoftDeleteArticle.class, NonQuotingDialect.INSTANCE).getSoftDeleteById())
-			.isEqualTo("UPDATE string_value_article SET x_state = :x_state WHERE string_value_article.x_id = :id");
+		assertThat(
+			createSqlGenerator(StringValueSoftDeleteArticle.class, NonQuotingDialect.INSTANCE).getSoftDeleteById()
+		).isEqualTo(
+			"UPDATE string_value_article SET x_state = :x_state WHERE string_value_article.x_id = :id"
+		);
 	}
 
 	@Test
 	void softDeleteByIdInWithBoolean() {
-		assertThat(createSqlGenerator(BooleanValueSoftDeleteArticle.class, NonQuotingDialect.INSTANCE).getSoftDeleteByIdIn())
-			.isEqualTo("UPDATE boolean_value_article SET x_deleted = :x_deleted WHERE boolean_value_article.x_id IN (:ids)");
+		assertThat(
+			createSqlGenerator(BooleanValueSoftDeleteArticle.class, NonQuotingDialect.INSTANCE).getSoftDeleteByIdIn()
+		).isEqualTo(
+			"UPDATE boolean_value_article SET x_deleted = :x_deleted WHERE boolean_value_article.x_id IN (:ids)"
+		);
 	}
 
 	@Test
 	void softDeleteByIdInWithString() {
-		assertThat(createSqlGenerator(StringValueSoftDeleteArticle.class, NonQuotingDialect.INSTANCE).getSoftDeleteByIdIn())
-			.isEqualTo("UPDATE string_value_article SET x_state = :x_state WHERE string_value_article.x_id IN (:ids)");
+		assertThat(
+			createSqlGenerator(StringValueSoftDeleteArticle.class, NonQuotingDialect.INSTANCE).getSoftDeleteByIdIn()
+		).isEqualTo(
+			"UPDATE string_value_article SET x_state = :x_state WHERE string_value_article.x_id IN (:ids)"
+		);
 	}
 
 	@Test
@@ -866,24 +878,34 @@ class SqlGeneratorTest {
 
 	@Test
 	void softDeleteByIdAndVersionWithBoolean() {
-		assertThat(createSqlGenerator(BooleanValueSoftDeleteArticle.class, NonQuotingDialect.INSTANCE).getSoftDeleteByIdAndVersion())
-			.isEqualTo(
-				"UPDATE boolean_value_article "
-					+ "SET x_deleted = :x_deleted "
-					+ "WHERE boolean_value_article.x_id = :id "
-					+ "AND boolean_value_article.x_version = :___oldOptimisticLockingVersion"
-			);
+		assertThat(
+			createSqlGenerator(
+				BooleanValueSoftDeleteArticle.class,
+				NonQuotingDialect.INSTANCE
+			).getSoftDeleteByIdAndVersion()
+		).isEqualTo(
+			"UPDATE boolean_value_article "
+				+ "SET x_deleted = :x_deleted, "
+				+ "x_version = :x_version "
+				+ "WHERE boolean_value_article.x_id = :id "
+				+ "AND boolean_value_article.x_version = :___oldOptimisticLockingVersion"
+		);
 	}
 
 	@Test
 	void softDeleteByIdAndVersionWithString() {
-		assertThat(createSqlGenerator(StringValueSoftDeleteArticle.class, NonQuotingDialect.INSTANCE).getSoftDeleteByIdAndVersion())
-			.isEqualTo(
-				"UPDATE string_value_article "
-					+ "SET x_state = :x_state "
-					+ "WHERE string_value_article.x_id = :id "
-					+ "AND string_value_article.x_version = :___oldOptimisticLockingVersion"
-			);
+		assertThat(
+			createSqlGenerator(
+				StringValueSoftDeleteArticle.class,
+				NonQuotingDialect.INSTANCE
+			).getSoftDeleteByIdAndVersion()
+		).isEqualTo(
+			"UPDATE string_value_article "
+				+ "SET x_state = :x_state, "
+				+ "x_version = :x_version "
+				+ "WHERE string_value_article.x_id = :id "
+				+ "AND string_value_article.x_version = :___oldOptimisticLockingVersion"
+		);
 	}
 
 	private SqlIdentifier getAlias(Object maybeAliased) {

--- a/spring-data-jdbc-plus-support/src/test/java/com/navercorp/spring/data/jdbc/plus/support/convert/SqlGeneratorTest.java
+++ b/spring-data-jdbc-plus-support/src/test/java/com/navercorp/spring/data/jdbc/plus/support/convert/SqlGeneratorTest.java
@@ -30,6 +30,7 @@ import org.springframework.data.relational.core.dialect.PostgresDialect;
 import org.springframework.data.relational.core.dialect.SqlServerDialect;
 import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.DefaultNamingStrategy;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
@@ -818,6 +819,52 @@ class SqlGeneratorTest {
 	}
 
 	@Test
+	public void softDeleteAll() {
+
+		String sql = createSqlGenerator(SoftDeleteArticle.class, NonQuotingDialect.INSTANCE)
+			.createSoftDeleteAllSql(null);
+
+		assertThat(sql).isEqualTo("UPDATE article SET x_deleted = :x_deleted");
+	}
+
+	@Test
+	public void cascadingSoftDeleteAllFirstLevel() {
+
+		String sql = createSqlGenerator(SoftDeleteArticle.class, NonQuotingDialect.INSTANCE)
+			.createSoftDeleteAllSql(getPath("ref", SoftDeleteArticle.class));
+
+		assertThat(sql).isEqualTo(
+			"UPDATE referenced_article "
+				+ "SET x_reference_deleted = :x_reference_deleted "
+				+ "WHERE referenced_article.article IS NOT NULL");
+	}
+
+	@Test
+	public void cascadingSoftDeleteAllSecondLevel() {
+
+		String sql = createSqlGenerator(SoftDeleteArticle.class, NonQuotingDialect.INSTANCE)
+			.createSoftDeleteAllSql(getPath("ref.further", SoftDeleteArticle.class));
+
+		assertThat(sql).isEqualTo(
+			"UPDATE second_referenced_article "
+				+ "SET x_second_reference_deleted = :x_second_reference_deleted "
+				+ "WHERE second_referenced_article.referenced_article IN ("
+				+ "SELECT referenced_article.x_id FROM referenced_article "
+				+ "WHERE referenced_article.article IS NOT NULL)");
+	}
+
+	@Test
+	public void softDeleteAllMap() {
+
+		String sql = createSqlGenerator(SoftDeleteArticle.class, NonQuotingDialect.INSTANCE)
+			.createSoftDeleteAllSql(getPath("mappedElements", SoftDeleteArticle.class));
+
+		assertThat(sql).isEqualTo("UPDATE soft_delete_element "
+			+ "SET x_element_deleted = :x_element_deleted "
+			+ "WHERE soft_delete_element.article IS NOT NULL");
+	}
+
+	@Test
 	void softDeleteByIdAndVersionWithBoolean() {
 		assertThat(createSqlGenerator(BooleanValueSoftDeleteArticle.class, NonQuotingDialect.INSTANCE).getSoftDeleteByIdAndVersion())
 			.isEqualTo(
@@ -940,11 +987,11 @@ class SqlGeneratorTest {
 		String name;
 	}
 
-	private static class PrefixingNamingStrategy implements NamingStrategy {
+	private static class PrefixingNamingStrategy extends DefaultNamingStrategy {
 
 		@Override
 		public String getColumnName(RelationalPersistentProperty property) {
-			return "x_" + NamingStrategy.super.getColumnName(property);
+			return "x_" + super.getColumnName(property);
 		}
 
 	}
@@ -1101,5 +1148,43 @@ class SqlGeneratorTest {
 
 		@Version
 		Integer version;
+
+		ReferencedSoftDeleteArticle ref;
+
+		Map<Integer, SoftDeleteElement> mappedElements;
+	}
+
+	@Table("referenced_article")
+	static class ReferencedSoftDeleteArticle {
+
+		@Id
+		Long id;
+
+		String contents;
+
+		@SoftDeleteColumn(type = ValueType.BOOLEAN, valueAsDeleted = "true")
+		boolean reference_deleted;
+
+		SecondReferencedSoftDeleteArticle further;
+	}
+
+	@Table("second_referenced_article")
+	static class SecondReferencedSoftDeleteArticle {
+
+		@Id
+		Long id;
+
+		String contents;
+
+		@SoftDeleteColumn(type = ValueType.BOOLEAN, valueAsDeleted = "true")
+		boolean second_reference_deleted;
+	}
+
+	@Table("soft_delete_element")
+	static class SoftDeleteElement {
+		@Id
+		Long id;
+		@SoftDeleteColumn(type = ValueType.BOOLEAN, valueAsDeleted = "true")
+		boolean element_deleted;
 	}
 }


### PR DESCRIPTION
- add examples into guide projects
- override initializing `dataAccessStrategyBean`
     - create `AbstractJdbcPlusConfiguration` to use auto configuration
     - modify FactoryBean
- change `SoftDeleteProperty` from concrete class to interface (for upper visibility)
- add `JdbcPlusDataAccessStrategy` to override `delete**` features
    - extends `DelegatingDataAccessStrategy`
- fix bug in delete with version
    - version column wasn't update