### PR TITLE
Remove unused kotlin dependency

### DIFF
--- a/spring-data-jdbc-plus-sql/build.gradle
+++ b/spring-data-jdbc-plus-sql/build.gradle
@@ -5,8 +5,6 @@ dependencies {
     api(project(":spring-jdbc-plus-support"))
     api(project(":spring-data-jdbc-plus-support"))
 
-    compileOnly("org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}")
-    compileOnly("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
     compileOnly("io.projectreactor:reactor-core")
 
     testImplementation("org.junit.jupiter:junit-jupiter")


### PR DESCRIPTION
I found in working on https://github.com/naver/spring-jdbc-plus/issues/142

There is no kotlin file in `spring-data-jdbc-plus-sql` module & bulid passes.

I'm not sure if it's really not used. If it's intended dependency, close the PR please.