### PR TITLE
Replace ResultSet to RowDocument in AggregateResultJdbcConverter

### DIFF
--- a/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/AggregateResultJdbcConverter.java
+++ b/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/AggregateResultJdbcConverter.java
@@ -549,7 +549,7 @@ public class AggregateResultJdbcConverter extends MappingJdbcConverter {
 	 * @param <P> the type parameter
 	 * @deprecated no usage in spring-jdbc-plus, to be removed.
 	 */
-	@Deprecated(since = "3.4.1", forRemoval = true)
+	@Deprecated(since = "3.5.0", forRemoval = true)
 	protected interface MapParameterValueProvider<P extends PersistentProperty<P>> {
 		/**
 		 * Gets parameter value.

--- a/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/JdbcBackReferencePropertyValueProvider.java
+++ b/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/JdbcBackReferencePropertyValueProvider.java
@@ -19,12 +19,13 @@ package com.navercorp.spring.data.jdbc.plus.sql.convert;
 import org.springframework.data.mapping.model.PropertyValueProvider;
 import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.data.relational.domain.RowDocument;
 
 import com.navercorp.spring.data.jdbc.plus.support.convert.PropertyPathUtils;
 
 /**
- * {@link PropertyValueProvider} obtaining values from a ResultSetAccessor. For a given id property it provides
- * the value in the resultset under which other entities refer back to it.
+ * {@link PropertyValueProvider} obtaining values from a RowDocument. For a given id property it provides
+ * the value in the rowdocument under which other entities refer back to it.
  *
  * @author Jens Schauder
  * @author Myeonghyeon Lee
@@ -35,26 +36,26 @@ import com.navercorp.spring.data.jdbc.plus.support.convert.PropertyPathUtils;
  */
 class JdbcBackReferencePropertyValueProvider implements PropertyValueProvider<RelationalPersistentProperty> {
 	private final AggregatePath basePath;
-	private final ResultSetAccessor resultSet;
+	private final RowDocument rowDocument;
 
 	/**
 	 * @param basePath path from the aggregate root relative to which all properties get resolved.
-	 * @param resultSet the ResultSetAccessor from which to obtain the actual values.
+	 * @param rowDocument the rowDocument from which to obtain the actual values.
 	 */
-	JdbcBackReferencePropertyValueProvider(AggregatePath basePath, ResultSetAccessor resultSet) {
+	JdbcBackReferencePropertyValueProvider(AggregatePath basePath, RowDocument rowDocument) {
 
-		this.resultSet = resultSet;
+		this.rowDocument = rowDocument;
 		this.basePath = basePath;
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> T getPropertyValue(RelationalPersistentProperty property) {
-		return (T)resultSet.getObject(PropertyPathUtils.getReverseColumnAlias(basePath.append(property))
+		return (T)rowDocument.get(PropertyPathUtils.getReverseColumnAlias(basePath.append(property))
 			.getReference());
 	}
 
 	public JdbcBackReferencePropertyValueProvider extendBy(RelationalPersistentProperty property) {
-		return new JdbcBackReferencePropertyValueProvider(basePath.append(property), resultSet);
+		return new JdbcBackReferencePropertyValueProvider(basePath.append(property), rowDocument);
 	}
 }

--- a/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/JdbcPropertyValueProvider.java
+++ b/spring-data-jdbc-plus-sql/src/main/java/com/navercorp/spring/data/jdbc/plus/sql/convert/JdbcPropertyValueProvider.java
@@ -19,11 +19,12 @@ package com.navercorp.spring.data.jdbc.plus.sql.convert;
 import org.springframework.data.mapping.model.PropertyValueProvider;
 import org.springframework.data.relational.core.mapping.AggregatePath;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.data.relational.domain.RowDocument;
 
 import com.navercorp.spring.data.jdbc.plus.support.convert.PropertyPathUtils;
 
 /**
- * {@link PropertyValueProvider} obtaining values from a ResultSetAccessor.
+ * {@link PropertyValueProvider} obtaining values from a RowDocument.
  *
  * @author Jens Schauder
  * @author Myeonghyeon Lee
@@ -34,22 +35,22 @@ import com.navercorp.spring.data.jdbc.plus.support.convert.PropertyPathUtils;
  */
 class JdbcPropertyValueProvider implements PropertyValueProvider<RelationalPersistentProperty> {
 	private final AggregatePath basePath;
-	private final ResultSetAccessor resultSet;
+	private final RowDocument rowDocument;
 
 	/**
 	 * @param basePath path from the aggregate root relative to which all properties get resolved.
-	 * @param resultSet the ResultSetAccessor from which to obtain the actual values.
+	 * @param rowDocument the RowDocument from which to obtain the actual values.
 	 */
-	JdbcPropertyValueProvider(AggregatePath basePath, ResultSetAccessor resultSet) {
+	JdbcPropertyValueProvider(AggregatePath basePath, RowDocument rowDocument) {
 
-		this.resultSet = resultSet;
+		this.rowDocument = rowDocument;
 		this.basePath = basePath;
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> T getPropertyValue(RelationalPersistentProperty property) {
-		return (T)resultSet.getObject(getColumnName(property));
+		return (T)rowDocument.get(getColumnName(property));
 	}
 
 	/**
@@ -60,7 +61,7 @@ class JdbcPropertyValueProvider implements PropertyValueProvider<RelationalPersi
 	 * @return
 	 */
 	public boolean hasProperty(RelationalPersistentProperty property) {
-		return resultSet.hasValue(getColumnName(property));
+		return rowDocument.containsKey(getColumnName(property));
 	}
 
 	private String getColumnName(RelationalPersistentProperty property) {
@@ -69,6 +70,6 @@ class JdbcPropertyValueProvider implements PropertyValueProvider<RelationalPersi
 	}
 
 	public JdbcPropertyValueProvider extendBy(RelationalPersistentProperty property) {
-		return new JdbcPropertyValueProvider(basePath.append(property), resultSet);
+		return new JdbcPropertyValueProvider(basePath.append(property), rowDocument);
 	}
 }


### PR DESCRIPTION
Replace `ResultSet` to `RowDocument`, which used to fetch the DB value.
The current change does not mean much right now, but I think it can be lead to use converter implementations of spring-data-jdbc.

---

DB 조회 값을 가져오는 부분을 `ResultSet` 에서 `RowDocument` 로 변경합니다
현재 변경으로는 당장 큰 의미가 있지는 않지만, spring-data-jdbc 의 converter 구현으로 변경이 가능할 것 같습니다