### PR TITLE
Bump up spring boot version up to 3.5.0-M1

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -25,7 +25,7 @@ spring-projects/spring-data-commons
 https://github.com/spring-projects/spring-data-commons
 
 
-Spring Data Commons 3.4.3
+Spring Data Commons 3.5.0-M1
 Copyright (c) [2010-2019] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").
@@ -71,7 +71,7 @@ spring-projects/spring-data-jdbc
 https://github.com/spring-projects/spring-data-jdbc
 
 
-Spring Data Relational 3.4.3
+Spring Data Relational 3.5.0-M1
 Copyright (c) [2017-2019] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ may be an appropriate choice.
             }
         }
         dependencies {
-            classpath("org.springframework.boot:spring-boot-gradle-plugin:3.4.3")
+            classpath("org.springframework.boot:spring-boot-gradle-plugin:3.5.0-M1")
         }
     }
 
     dependencies {
         implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
-        implementation("com.navercorp.spring:spring-boot-starter-data-jdbc-plus-sql:3.4.3")
+        implementation("com.navercorp.spring:spring-boot-starter-data-jdbc-plus-sql:3.5.0-M1")
     }
     ```
 
@@ -51,7 +51,7 @@ may be an appropriate choice.
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.3</version>
+        <version>3.5.0-M1</version>
         <relativePath/>
     </parent>
 
@@ -63,7 +63,7 @@ may be an appropriate choice.
     <dependency>
         <groupId>com.navercorp.spring</groupId>
         <artifactId>spring-boot-starter-data-jdbc-plus-sql</artifactId>
-        <version>3.4.3</version>
+        <version>3.5.0-M1</version>
     </dependency>
     ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-springBootVersion=3.4.3
-springDataBomVersion=2024.1.3
+springBootVersion=3.5.0-M1
+springDataBomVersion=2025.0.0-M1

--- a/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProductRepository.java
+++ b/guide-projects/plus-repository-guide/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProductRepository.java
@@ -1,0 +1,6 @@
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import com.navercorp.spring.data.jdbc.plus.repository.JdbcRepository;
+
+public interface PlainProductRepository extends JdbcRepository<PlainProduct, Long> {
+}

--- a/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProductRepositoryTest.java
+++ b/guide-projects/plus-repository-guide/src/test/java/com/navercorp/spring/data/jdbc/plus/repository/guide/product/PlainProductRepositoryTest.java
@@ -1,0 +1,104 @@
+package com.navercorp.spring.data.jdbc.plus.repository.guide.product;
+
+import static org.assertj.core.api.BDDAssertions.*;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.relational.core.query.Criteria;
+import org.springframework.data.relational.core.query.Query;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author Chanwool Jo
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class PlainProductRepositoryTest {
+	@Autowired
+	private PlainProductRepository sut;
+
+	private final List<PlainProduct> products = Arrays.asList(
+		PlainProduct.builder()
+			.id(1L)
+			.productName("product1")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.build(),
+		PlainProduct.builder()
+			.id(2L)
+			.productName("product2")
+			.createdAt(Instant.now())
+			.lastModifiedAt(Instant.now())
+			.build()
+	);
+
+	@Test
+	void streamAll() {
+		// given
+		sut.insertAll(products);
+
+		// when
+		try (Stream<PlainProduct> actual = sut.streamAll()) {
+			// then
+			then(actual).allSatisfy(it -> {
+				then(it.getProductName()).startsWith("product");
+			});
+		}
+	}
+
+	@Test
+	void streamAllByQuery() {
+		// given
+		sut.insertAll(products);
+		Query query = Query.query(Criteria.where("productName").is("product1"));
+
+		// when
+		try (Stream<PlainProduct> actual = sut.streamAll(query)) {
+			// then
+			then(actual).allSatisfy(it -> {
+				then(it.getProductName()).isEqualTo("product1");
+			});
+		}
+	}
+
+	@Test
+	void streamAllWithSorting() {
+		// given
+		sut.insertAll(products);
+		Sort sort = Sort.by(Sort.Order.desc("id"));
+
+		// when
+		try (Stream<PlainProduct> actual = sut.streamAll(sort)) {
+			// then
+			then(actual).isSortedAccordingTo(Comparator.comparing(PlainProduct::getId).reversed());
+		}
+	}
+
+	@Test
+	void streamAllByIds() {
+		// given
+		sut.insertAll(products);
+		Set<Long> ids = Set.of(1L);
+
+		// when
+		try (Stream<PlainProduct> actual = sut.streamAllByIds(ids)) {
+			// then
+			then(actual).allSatisfy(it -> {
+				then(it.getId()).isEqualTo(1L);
+				then(it.getProductName()).isEqualTo("product1");
+			});
+		}
+	}
+}

--- a/spring-data-jdbc-plus-repository/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/JdbcRepository.java
+++ b/spring-data-jdbc-plus-repository/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/JdbcRepository.java
@@ -19,7 +19,10 @@
 package com.navercorp.spring.data.jdbc.plus.repository;
 
 import java.util.List;
+import java.util.stream.Stream;
 
+import org.springframework.data.domain.Sort;
+import org.springframework.data.relational.core.query.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.PagingAndSortingRepository;
@@ -72,4 +75,12 @@ public interface JdbcRepository<T, ID>
 	 * @return the iterable
 	 */
 	<S extends T> List<S> updateAll(Iterable<S> entities);
+
+	Stream<T> streamAll();
+
+	Stream<T> streamAll(Sort sort);
+
+	Stream<T> streamAll(Query query);
+
+	Stream<T> streamAllByIds(Iterable<ID> ids);
 }

--- a/spring-data-jdbc-plus-repository/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/support/JdbcPlusRepository.java
+++ b/spring-data-jdbc-plus-repository/src/main/java/com/navercorp/spring/data/jdbc/plus/repository/support/JdbcPlusRepository.java
@@ -19,11 +19,14 @@
 package com.navercorp.spring.data.jdbc.plus.repository.support;
 
 import java.util.List;
+import java.util.stream.Stream;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jdbc.core.JdbcAggregateOperations;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.repository.support.SimpleJdbcRepository;
 import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.relational.core.query.Query;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.navercorp.spring.data.jdbc.plus.repository.JdbcRepository;
@@ -41,6 +44,7 @@ import com.navercorp.spring.data.jdbc.plus.repository.JdbcRepository;
  */
 public class JdbcPlusRepository<T, ID> extends SimpleJdbcRepository<T, ID> implements JdbcRepository<T, ID> {
 	private final JdbcAggregateOperations entityOperations;
+	private final PersistentEntity<T, ?> entity;
 
 	/**
 	 * Instantiates a new Jdbc plus repository.
@@ -52,6 +56,8 @@ public class JdbcPlusRepository<T, ID> extends SimpleJdbcRepository<T, ID> imple
 		JdbcAggregateOperations entityOperations, PersistentEntity<T, ?> entity, JdbcConverter converter) {
 
 		super(entityOperations, entity, converter);
+
+		this.entity = entity;
 		this.entityOperations = entityOperations;
 	}
 
@@ -77,5 +83,25 @@ public class JdbcPlusRepository<T, ID> extends SimpleJdbcRepository<T, ID> imple
 	@Override
 	public <S extends T> List<S> updateAll(Iterable<S> entities) {
 		return entityOperations.updateAll(entities);
+	}
+
+	@Override
+	public Stream<T> streamAll() {
+		return entityOperations.streamAll(entity.getType());
+	}
+
+	@Override
+	public Stream<T> streamAll(Sort sort) {
+		return entityOperations.streamAll(entity.getType(), sort);
+	}
+
+	@Override
+	public Stream<T> streamAll(Query query) {
+		return entityOperations.streamAll(query, entity.getType());
+	}
+
+	@Override
+	public Stream<T> streamAllByIds(Iterable<ID> ids) {
+		return entityOperations.streamAllByIds(ids, entity.getType());
 	}
 }


### PR DESCRIPTION
## Noteworthy commits in spring-data-relational

changelogs: https://github.com/spring-projects/spring-data-relational/compare/3.4.2...3.5.0-M1

- [Support derived delete.](https://github.com/spring-projects/spring-data-relational/commit/1515a3af42e73f6d2e79e005358f655d0309e40a)
- [Ignore collection like attributes for query by example.](https://github.com/spring-projects/spring-data-relational/commit/ece981f9f150dcf42c54bafc843995345407df90)
- [Add Stream support to JdbcAggregateOperations](https://github.com/spring-projects/spring-data-relational/commit/ea296429df9fc7b0521a17ea4b22d9fee14fb23e)

## Reflected Changes

This PR reflects the following change:

- [Add Stream support to JdbcAggregateOperations](https://github.com/spring-projects/spring-data-relational/commit/ea296429df9fc7b0521a17ea4b22d9fee14fb23e)

