### PR TITLE
[#166] Replace publish target

### DIFF
--- a/buildSrc/src/main/groovy/spring.jdbc.plus.maven-publish-conventions.gradle
+++ b/buildSrc/src/main/groovy/spring.jdbc.plus.maven-publish-conventions.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "maven-publish"
-    id "signing"
 }
 
 group = "com.navercorp.spring"
@@ -21,8 +20,8 @@ publishing {
                         password ossrhPassword
                     }
 
-                    def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-                    def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+                    def releasesRepoUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/"
+                    def snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
                     url = version.endsWith("SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl
                 }
             }
@@ -76,17 +75,4 @@ publishing {
             }
         }
     }
-}
-
-signing {
-    def signingKey = findProperty("signingKey")
-    def signingPassword = findProperty("signingPassword")
-
-    useInMemoryPgpKeys(signingKey, signingPassword)
-
-    sign publishing.publications.mavenJava
-}
-
-tasks.withType(Sign) {
-    onlyIf { !version.endsWith("SNAPSHOT") }
 }


### PR DESCRIPTION
The [legacy ossrh](https://central.sonatype.org/register/legacy/) was migrated to central sonatype.
We should change it.

I published snapshot, which is available in [this](https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/navercorp/spring/spring-boot-starter-data-jdbc-plus-repository/3.5.0-SNAPSHOT/).