### PR TITLE
Bump up spring boot version to 3.5.1

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -25,7 +25,7 @@ spring-projects/spring-data-commons
 https://github.com/spring-projects/spring-data-commons
 
 
-Spring Data Commons 3.5.0-M1
+Spring Data Commons 3.5.1
 Copyright (c) [2010-2019] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").
@@ -71,7 +71,7 @@ spring-projects/spring-data-jdbc
 https://github.com/spring-projects/spring-data-jdbc
 
 
-Spring Data Relational 3.5.0-M1
+Spring Data Relational 3.5.1
 Copyright (c) [2017-2019] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ may be an appropriate choice.
             }
         }
         dependencies {
-            classpath("org.springframework.boot:spring-boot-gradle-plugin:3.5.0-M1")
+            classpath("org.springframework.boot:spring-boot-gradle-plugin:3.5.1")
         }
     }
 
     dependencies {
         implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
-        implementation("com.navercorp.spring:spring-boot-starter-data-jdbc-plus-sql:3.5.0-M1")
+        implementation("com.navercorp.spring:spring-boot-starter-data-jdbc-plus-sql:3.5.1")
     }
     ```
 
@@ -51,7 +51,7 @@ may be an appropriate choice.
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.0-M1</version>
+        <version>3.5.1</version>
         <relativePath/>
     </parent>
 
@@ -63,7 +63,7 @@ may be an appropriate choice.
     <dependency>
         <groupId>com.navercorp.spring</groupId>
         <artifactId>spring-boot-starter-data-jdbc-plus-sql</artifactId>
-        <version>3.5.0-M1</version>
+        <version>3.5.1</version>
     </dependency>
     ```
 

--- a/buildSrc/src/main/groovy/spring.jdbc.plus.maven-publish-conventions.gradle
+++ b/buildSrc/src/main/groovy/spring.jdbc.plus.maven-publish-conventions.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.navercorp.spring"
-version = "3.5.0-SNAPSHOT"
+version = "3.5.1"
 
 publishing {
     publications {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-springBootVersion=3.5.0-M1
-springDataBomVersion=2025.0.0-M1
+springBootVersion=3.5.1
+springDataBomVersion=2025.0.1

--- a/guide-projects/plus-repository-guide/build.gradle
+++ b/guide-projects/plus-repository-guide/build.gradle
@@ -18,4 +18,5 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/guide-projects/plus-sql-java-groovy-guide/build.gradle
+++ b/guide-projects/plus-sql-java-groovy-guide/build.gradle
@@ -53,4 +53,5 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testCompileOnly("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/guide-projects/plus-sql-java-kotlin-guide/build.gradle
+++ b/guide-projects/plus-sql-java-kotlin-guide/build.gradle
@@ -37,4 +37,5 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/guide-projects/plus-sql-kotlin-guide/build.gradle.kts
+++ b/guide-projects/plus-sql-kotlin-guide/build.gradle.kts
@@ -25,4 +25,5 @@ dependencies {
     implementation("org.springframework.data:spring-data-commons")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }


### PR DESCRIPTION
## Noteworthy commits in spring-data-relational

changelogs: https://github.com/spring-projects/spring-data-relational/compare/3.5.0-M1...3.5.1

- Move Sequence to RelationalPersistentProperty.
  - https://github.com/spring-projects/spring-data-relational/commit/0fc318791668c294dbde984ba4879a8cf5248ca9
  - https://github.com/spring-projects/spring-data-relational/commit/eb25cc3ed44e05a22b0ee5c442e3b4107003e72e
- Fix performance bug with large number of unnamed parameters
  - https://github.com/spring-projects/spring-data-relational/commit/58a3f01ccd285999c86293e751ea04d821fad931
- Applies proper event handling before saving in batch.
  - https://github.com/spring-projects/spring-data-relational/commit/651a4f5a1959c51857bedf32ce72d408d1d5a1a6
- JdbcAggregateTemplate honors columns specified in query.
  - https://github.com/spring-projects/spring-data-relational/commit/2ca8f4fb6f5827b73ce2adc8aeb29b9b2cb9e4f4

## Upgrade Notes

No specific actions are required to upgrade from the previous version.