### PR TITLE
Replace publish config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,5 +34,3 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USER_NAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_USER_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/buildSrc/src/main/groovy/spring.jdbc.plus.maven-publish-conventions.gradle
+++ b/buildSrc/src/main/groovy/spring.jdbc.plus.maven-publish-conventions.gradle
@@ -20,7 +20,7 @@ publishing {
                         password ossrhPassword
                     }
 
-                    def releasesRepoUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/"
+                    def releasesRepoUrl = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
                     def snapshotsRepoUrl = "https://central.sonatype.com/repository/maven-snapshots/"
                     url = version.endsWith("SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl
                 }


### PR DESCRIPTION
related #166

- remove unused env in publish.yml
- change url for maven-publish plugin

https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration

url is different for `maven-publish` plugin