### PR TITLE
Revive publish signing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,3 +34,5 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USER_NAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_USER_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/buildSrc/src/main/groovy/spring.jdbc.plus.maven-publish-conventions.gradle
+++ b/buildSrc/src/main/groovy/spring.jdbc.plus.maven-publish-conventions.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "maven-publish"
+    id "signing"
 }
 
 group = "com.navercorp.spring"
@@ -75,4 +76,17 @@ publishing {
             }
         }
     }
+}
+
+signing {
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+
+    useInMemoryPgpKeys(signingKey, signingPassword)
+
+    sign publishing.publications.mavenJava
+}
+
+tasks.withType(Sign) {
+    onlyIf { !version.endsWith("SNAPSHOT") }
 }


### PR DESCRIPTION
I misunderstood about signing. It's still a required operation (https://central.sonatype.org/publish/requirements/gpg/#distributing-your-public-key).